### PR TITLE
feat: add refresh access token service

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -6,6 +6,7 @@ import { LateFilingPenaltyService } from "./services/lfp";
 import { BasketService, OrderService, CertificateService, CertifiedCopiesService, MidService } from "./services/order/";
 import { PaymentService } from "./services/payment/";
 import CompanyFilingHistoryService from "./services/company-filing-history/service";
+import { RefreshTokenService } from "./services/refresh-token";
 
 /**
  * ApiClient is the class that all service objects hang off.
@@ -22,6 +23,7 @@ export default class ApiClient {
   public readonly payment: PaymentService;
   public readonly order: OrderService;
   public readonly mid : MidService;
+  public readonly refreshToken: RefreshTokenService;
 
   constructor (readonly apiClient: IHttpClient, readonly accountClient: IHttpClient) {
       // services on the api domain using the apiClient
@@ -38,5 +40,6 @@ export default class ApiClient {
       this.mid = new MidService(apiClient);
       // service on the account/identity domain using the accountClient
       // e.g. user profile service can be added here when required
+      this.refreshToken = new RefreshTokenService(accountClient);
   }
 }

--- a/src/services/refresh-token/index.ts
+++ b/src/services/refresh-token/index.ts
@@ -1,0 +1,2 @@
+export { default as RefreshTokenService } from "./service";
+export * from "./types";

--- a/src/services/refresh-token/service.ts
+++ b/src/services/refresh-token/service.ts
@@ -3,8 +3,7 @@ import { RefreshTokenData } from "./types";
 import Resource from "../resource";
 
 export default class {
-    constructor (private readonly client: IHttpClient) {
-    }
+    constructor (private readonly client: IHttpClient) {}
 
     public async refresh (refreshToken: string, grantType: string, clientId: string,
         clientSecret: string): Promise<Resource<RefreshTokenData>> {

--- a/src/services/refresh-token/service.ts
+++ b/src/services/refresh-token/service.ts
@@ -1,0 +1,34 @@
+import { IHttpClient } from "../../http";
+import { RefreshTokenData } from "./types";
+import Resource from "../resource";
+
+export default class {
+    constructor (private readonly client: IHttpClient) {
+    }
+
+    public async refresh (refreshToken: string, grantType: string, clientId: string,
+        clientSecret: string): Promise<Resource<RefreshTokenData>> {
+        const url: string = `/oauth2/token?grant_type=${grantType}&refresh_token=${refreshToken}&client_id=${clientId}` +
+            `&client_secret=${clientSecret}`;
+
+        const response = await this.client.httpPost(url);
+
+        const resource: Resource<RefreshTokenData> = {
+            httpStatusCode: response.status
+        };
+
+        if (response.error) {
+            return resource;
+        }
+
+        const body = response.body as RefreshTokenData;
+
+        resource.resource = {
+            expires_in: body.expires_in,
+            token_type: body.token_type,
+            access_token: body.access_token
+        };
+
+        return resource;
+    }
+}

--- a/src/services/refresh-token/types.ts
+++ b/src/services/refresh-token/types.ts
@@ -1,0 +1,5 @@
+export interface RefreshTokenData {
+    expires_in: number;
+    token_type: string;
+    access_token: string;
+}

--- a/test/services/refresh-token/service.spec.ts
+++ b/test/services/refresh-token/service.spec.ts
@@ -1,0 +1,81 @@
+import { RequestClient } from "../../../src/http";
+import { RefreshTokenService } from "../../../src/services/refresh-token";
+import chai from "chai";
+import sinon from "sinon";
+const expect = chai.expect;
+const requestClient = new RequestClient({ baseUrl: "URL-NOT-USED", oauthToken: "TOKEN-NOT-USED" });
+
+describe("refresh token", () => {
+    beforeEach(() => {
+        sinon.reset();
+        sinon.restore();
+    });
+
+    afterEach(done => {
+        sinon.reset();
+        sinon.restore();
+        done();
+    });
+
+    it("returns an error response on failure", async () => {
+
+        sinon.stub(requestClient, "httpPost").resolves({
+            status: 400,
+            error: "Invalid parameter"
+        });
+
+        const refreshToken: RefreshTokenService = new RefreshTokenService(requestClient);
+
+        const data = await refreshToken.refresh("REFRESH_TOKEN", "GRANT_TYPE", "CLIENT_ID",
+            "CLIENT_SECRET");
+
+        expect(data.httpStatusCode).to.be.equal(400);
+        expect(data.resource).to.be.undefined;
+    });
+
+    it("maps the refresh token data correctly", async () => {
+        const mockResponseBody = ({
+            access_token: "string",
+            token_type: "string",
+            expires_in: 1
+        });
+
+        sinon.stub(requestClient, "httpPost").resolves({
+            status: 200,
+            body: mockResponseBody
+        });
+
+        const refreshToken: RefreshTokenService = new RefreshTokenService(requestClient);
+
+        const data = await refreshToken.refresh("REFRESH_TOKEN", "GRANT_TYPE", "CLIENT_ID",
+            "CLIENT_SECRET");
+
+        expect(data.httpStatusCode).to.be.equal(200);
+        expect(data.resource.access_token).to.be.equal(mockResponseBody.access_token);
+        expect(data.resource.token_type).to.be.equal(mockResponseBody.token_type);
+        expect(data.resource.expires_in).to.be.equal(mockResponseBody.expires_in);
+    });
+
+    it("maps the refresh token data correctly when fields are missing", async () => {
+        const mockResponseBody = ({
+            access_token: "string",
+            token_type: undefined,
+            expires_in: 1
+        });
+
+        sinon.stub(requestClient, "httpPost").resolves({
+            status: 200,
+            body: mockResponseBody
+        });
+
+        const refreshToken: RefreshTokenService = new RefreshTokenService(requestClient);
+
+        const data = await refreshToken.refresh("REFRESH_TOKEN", "GRANT_TYPE", "CLIENT_ID",
+            "CLIENT_SECRET");
+
+        expect(data.httpStatusCode).to.be.equal(200);
+        expect(data.resource.access_token).to.be.equal(mockResponseBody.access_token);
+        expect(data.resource.token_type).to.be.equal(undefined);
+        expect(data.resource.expires_in).to.be.equal(mockResponseBody.expires_in);
+    });
+});


### PR DESCRIPTION
JIRA: https://companieshouse.atlassian.net/browse/SR-129

Added a new `RefreshTokenService` on the Account domain using the `accountClient`, which supports refreshing user session access tokens for API requests.