### PR TITLE
Add logic to getCompanies to determine correct end point to query

### DIFF
--- a/src/services/search/dissolved-search/service.ts
+++ b/src/services/search/dissolved-search/service.ts
@@ -4,12 +4,21 @@ import Resource from "../../resource";
 
 export default class DissolvedSearchService {
     constructor (private readonly client: IHttpClient) { }
-    public async getCompanies (companyName: string, requestId: string): Promise<Resource<CompaniesResource>> {
+    public async getCompanies (companyName: string, requestId: string, searchType: string): Promise<Resource<CompaniesResource>> {
         const additionalHeaders = {
             "X-Request-ID": requestId,
             "Content-Type": "application/json"
         }
-        const dissolvedSearchURL = "/dissolved-search/companies?q=" + companyName;
+        const ALPHABETICAL_QUERY = "&search_type=alphabetical";
+        const BEST_MATCH_QUERY = "&search_type=best-match";
+
+        let dissolvedSearchURL = "/dissolved-search/companies?q=" + companyName;
+
+        if (searchType === "alphabetical") {
+            dissolvedSearchURL += ALPHABETICAL_QUERY;
+        } else {
+            dissolvedSearchURL += BEST_MATCH_QUERY;
+        };
 
         const resp = await this.client.httpGet(dissolvedSearchURL, additionalHeaders);
 

--- a/test/services/search/dissolved-search/service.spec.ts
+++ b/test/services/search/dissolved-search/service.spec.ts
@@ -56,6 +56,7 @@ const mockResponseBody : CompaniesResource = ({
 
 const mockRequestId = "fdskfhsdoifhsffsif";
 const testCompanyName = "TEST COMPANY NAME";
+const searchType = "alphabetical";
 
 describe("create a dissolved search GET", () => {
     beforeEach(() => {
@@ -77,7 +78,7 @@ describe("create a dissolved search GET", () => {
 
         const mockRequest = sinon.stub(requestClient, "httpGet").resolves(mockGetRequest);
         const search: DissolvedSearchService = new DissolvedSearchService(requestClient);
-        const data: Resource<CompaniesResource> = await search.getCompanies(testCompanyName, mockRequestId);
+        const data: Resource<CompaniesResource> = await search.getCompanies(testCompanyName, mockRequestId, searchType);
 
         expect(data.httpStatusCode).to.equal(401);
         expect(data.resource).to.be.undefined;
@@ -91,7 +92,7 @@ describe("create a dissolved search GET", () => {
 
         const mockRequest = sinon.stub(requestClient, "httpGet").resolves(mockGetRequest);
         const search: DissolvedSearchService = new DissolvedSearchService(requestClient);
-        const data: Resource<CompaniesResource> = await search.getCompanies(testCompanyName, mockRequestId);
+        const data: Resource<CompaniesResource> = await search.getCompanies(testCompanyName, mockRequestId, searchType);
         const item = data.resource.items[0];
         const mockItem = mockResponseBody.items[0];
 


### PR DESCRIPTION
Add searchType parameter to getCompanies function in dissolved search service to  be used to determine correct api end point to query.

Resolves: BI-7129