### PR TITLE
NCS-89 Adding last_made_up_to and next_made_up_to Confirmation Statem…

### DIFF
--- a/src/services/company-profile/service.ts
+++ b/src/services/company-profile/service.ts
@@ -73,7 +73,9 @@ export default class CompanyProfileService {
                 overdue: acc?.overdue
             },
             confirmationStatement: {
+                lastMadeUpTo: confirmationStatement?.last_made_up_to,
                 nextDue: confirmationStatement?.next_due,
+                nextMadeUpTo: confirmationStatement?.next_made_up_to,
                 overdue: confirmationStatement?.overdue
             },
             links: {

--- a/src/services/company-profile/types.ts
+++ b/src/services/company-profile/types.ts
@@ -44,7 +44,9 @@ export interface NextAccountsResource {
 }
 
 export interface ConfirmationStatementResource {
+  last_made_up_to?: string;
   next_due: string;
+  next_made_up_to?: string;
   overdue: boolean;
 }
 
@@ -76,7 +78,9 @@ export interface NextAccounts {
 }
 
 export interface ConfirmationStatement {
+  lastMadeUpTo?: string;
   nextDue: string;
+  nextMadeUpTo?: string;
   overdue: boolean;
 }
 

--- a/test/services/company-profile/service.spec.ts
+++ b/test/services/company-profile/service.spec.ts
@@ -70,7 +70,9 @@ describe("company-profile", () => {
                 overdue: true
             },
             confirmation_statement: {
+                last_made_up_to: "2018-08-24",
                 next_due: "2019-08-24",
+                next_made_up_to: "2019-07-20",
                 overdue: true
             },
             links: {
@@ -113,7 +115,9 @@ describe("company-profile", () => {
         expect(data.resource.accounts.nextAccounts.periodStartOn).to.equal(mockResponseBody.accounts.next_accounts.period_start_on);
         expect(data.resource.accounts.nextDue).to.equal(mockResponseBody.accounts.next_due);
         expect(data.resource.accounts.overdue).to.equal(mockResponseBody.accounts.overdue);
+        expect(data.resource.confirmationStatement.lastMadeUpTo).to.equal(mockResponseBody.confirmation_statement.last_made_up_to);
         expect(data.resource.confirmationStatement.nextDue).to.equal(mockResponseBody.confirmation_statement.next_due);
+        expect(data.resource.confirmationStatement.nextMadeUpTo).to.equal(mockResponseBody.confirmation_statement.next_made_up_to);
         expect(data.resource.confirmationStatement.overdue).to.equal(mockResponseBody.confirmation_statement.overdue);
         expect(data.resource.links.filingHistory).to.equal(mockResponseBody.links.filing_history);
     });
@@ -171,7 +175,9 @@ describe("company-profile", () => {
         expect(data.resource.accounts.nextAccounts.periodStartOn).to.be.undefined;
         expect(data.resource.accounts.nextDue).to.be.undefined;
         expect(data.resource.accounts.overdue).to.be.undefined;
+        expect(data.resource.confirmationStatement.lastMadeUpTo).to.be.undefined;
         expect(data.resource.confirmationStatement.nextDue).to.be.undefined;
+        expect(data.resource.confirmationStatement.nextMadeUpTo).to.be.undefined;
         expect(data.resource.confirmationStatement.overdue).to.be.undefined;
         expect(data.resource.links.filingHistory).to.be.undefined;
         expect(data.resource.hasSuperSecurePscs).to.be.undefined;


### PR DESCRIPTION
…ent dates to Company Profile service

Adding last_made_up_to and next_made_up_to fields to the Confirmation Statement section of the Company Profile to be returned by the Company Profile service