### PR TITLE
add query params for dissolved search alphabetical update tests

### DIFF
--- a/src/services/search/dissolved-search/service.ts
+++ b/src/services/search/dissolved-search/service.ts
@@ -1,11 +1,9 @@
 import { IHttpClient } from "../../../http";
 import { CompaniesResource } from "./types";
 import Resource from "../../resource";
-import { start } from "repl";
-
 export default class DissolvedSearchService {
     constructor (private readonly client: IHttpClient) { }
-    public async getCompanies (companyName: string, requestId: string, searchType: string, startIndex: number): Promise<Resource<CompaniesResource>> {
+    public async getCompanies (companyName: string, requestId: string, searchType: string, startIndex: number | null, searchBefore: string | null, searchAfter: string | null, size: number | null): Promise<Resource<CompaniesResource>> {
         const additionalHeaders = {
             "X-Request-ID": requestId,
             "Content-Type": "application/json"
@@ -13,12 +11,24 @@ export default class DissolvedSearchService {
         const ALPHABETICAL_QUERY = "&search_type=alphabetical";
         const BEST_MATCH_QUERY = "&search_type=best-match";
         const PREVIOUS_NAME_QUERY = "&search_type=previous-name-dissolved";
-        const START_INDEX_QUERY = "&start_index=" + startIndex;
+        const START_INDEX_QUERY = "&start_index=";
+        const SEARCH_BEFORE_QUERY = "&search_before=";
+        const SEARCH_AFTER_QUERY = "&search_after=";
+        const SIZE_QUERY = "&size=";
 
         let dissolvedSearchURL = "/dissolved-search/companies?q=" + companyName;
 
         if (searchType === "alphabetical") {
-            dissolvedSearchURL += ALPHABETICAL_QUERY;
+            dissolvedSearchURL += ALPHABETICAL_QUERY
+            if (searchAfter !== null) {
+                dissolvedSearchURL += SEARCH_AFTER_QUERY + searchAfter;
+            }
+            if (searchBefore !== null) {
+                dissolvedSearchURL += SEARCH_BEFORE_QUERY + searchBefore;
+            }
+            if (size !== null) {
+                dissolvedSearchURL += SIZE_QUERY + size;
+            }
         }
 
         if (!startIndex && searchType === "previousNameDissolved") {

--- a/src/services/search/dissolved-search/types.ts
+++ b/src/services/search/dissolved-search/types.ts
@@ -14,6 +14,7 @@ export interface Items {
     date_of_cessation: Date;
     date_of_creation: Date;
     kind: string;
+    ordered_alpha_key_with_id: string;
     previous_company_names: PreviousCompanyNames[];
 }
 
@@ -36,5 +37,6 @@ export interface TopHit {
     date_of_cessation: Date;
     date_of_creation: Date;
     kind: string;
+    ordered_alpha_key_with_id: string;
     previous_company_names: PreviousCompanyNames[];
 }

--- a/test/services/search/dissolved-search/service.spec.ts
+++ b/test/services/search/dissolved-search/service.spec.ts
@@ -23,6 +23,7 @@ const mockResponseBody : CompaniesResource = ({
             date_of_cessation: (new Date("19910212")),
             date_of_creation: (new Date("19910212")),
             kind: "kind",
+            ordered_alpha_key_with_id: "testcompany:0000789",
             previous_company_names: [
                 {
                     ceased_on: (new Date("19910212")),
@@ -44,6 +45,7 @@ const mockResponseBody : CompaniesResource = ({
         date_of_cessation: (new Date("19910212")),
         date_of_creation: (new Date("19910212")),
         kind: "kind",
+        ordered_alpha_key_with_id: "testcompany:0000789",
         previous_company_names: [
             {
                 ceased_on: (new Date("19910212")),
@@ -59,6 +61,9 @@ const mockRequestId = "fdskfhsdoifhsffsif";
 const testCompanyName = "TEST COMPANY NAME";
 const searchType = "alphabetical";
 const startIndex = 0;
+const searchBefore = "testcompany:0000784"
+const searchafter = "testcompany:0000794"
+const page = 0
 
 describe("create a dissolved search GET", () => {
     beforeEach(() => {
@@ -80,7 +85,7 @@ describe("create a dissolved search GET", () => {
 
         const mockRequest = sinon.stub(requestClient, "httpGet").resolves(mockGetRequest);
         const search: DissolvedSearchService = new DissolvedSearchService(requestClient);
-        const data: Resource<CompaniesResource> = await search.getCompanies(testCompanyName, mockRequestId, searchType, startIndex);
+        const data: Resource<CompaniesResource> = await search.getCompanies(testCompanyName, mockRequestId, searchType, startIndex, searchBefore, searchafter, page);
 
         expect(data.httpStatusCode).to.equal(401);
         expect(data.resource).to.be.undefined;
@@ -94,7 +99,7 @@ describe("create a dissolved search GET", () => {
 
         const mockRequest = sinon.stub(requestClient, "httpGet").resolves(mockGetRequest);
         const search: DissolvedSearchService = new DissolvedSearchService(requestClient);
-        const data: Resource<CompaniesResource> = await search.getCompanies(testCompanyName, mockRequestId, searchType, startIndex);
+        const data: Resource<CompaniesResource> = await search.getCompanies(testCompanyName, mockRequestId, searchType, startIndex, searchBefore, searchafter, page);
         const item = data.resource.items[0];
         const mockItem = mockResponseBody.items[0];
 


### PR DESCRIPTION
Update dissolved search alphabetical to handle search before, search after and size query params to create the url being passed to the api.
Updated model ordered alphakey with id
Update test

Resolves: BI-7008