### PR TITLE
BI-8365: Update SDK to include matched_previous_names

### DIFF
--- a/src/services/search/dissolved-search/types.ts
+++ b/src/services/search/dissolved-search/types.ts
@@ -16,6 +16,7 @@ export interface Items {
     kind: string;
     ordered_alpha_key_with_id: string;
     previous_company_names: PreviousCompanyNames[];
+    matched_previous_company_names: MatchedPreviousCompanyNames[];
 }
 
 export interface Address {
@@ -26,6 +27,11 @@ export interface Address {
 }
 
 export interface PreviousCompanyNames {
+    ceased_on: Date;
+    effective_from: Date;
+    name: string;
+}
+export interface MatchedPreviousCompanyNames {
     ceased_on: Date;
     effective_from: Date;
     name: string;
@@ -41,4 +47,5 @@ export interface TopHit {
     kind: string;
     ordered_alpha_key_with_id: string;
     previous_company_names: PreviousCompanyNames[];
+    matched_previous_company_names: MatchedPreviousCompanyNames[];
 }

--- a/src/services/search/dissolved-search/types.ts
+++ b/src/services/search/dissolved-search/types.ts
@@ -16,7 +16,7 @@ export interface Items {
     kind: string;
     ordered_alpha_key_with_id: string;
     previous_company_names: PreviousCompanyNames[];
-    matched_previous_company_names: MatchedPreviousCompanyNames;
+    matched_previous_company_name: MatchedPreviousCompanyName;
 }
 
 export interface Address {
@@ -31,7 +31,7 @@ export interface PreviousCompanyNames {
     effective_from: Date;
     name: string;
 }
-export interface MatchedPreviousCompanyNames {
+export interface MatchedPreviousCompanyName {
     ceased_on: Date;
     effective_from: Date;
     name: string;
@@ -47,5 +47,5 @@ export interface TopHit {
     kind: string;
     ordered_alpha_key_with_id: string;
     previous_company_names: PreviousCompanyNames[];
-    matched_previous_company_names: MatchedPreviousCompanyNames;
+    matched_previous_company_name: MatchedPreviousCompanyName;
 }

--- a/src/services/search/dissolved-search/types.ts
+++ b/src/services/search/dissolved-search/types.ts
@@ -16,7 +16,7 @@ export interface Items {
     kind: string;
     ordered_alpha_key_with_id: string;
     previous_company_names: PreviousCompanyNames[];
-    matched_previous_company_names: MatchedPreviousCompanyNames[];
+    matched_previous_company_names: MatchedPreviousCompanyNames;
 }
 
 export interface Address {
@@ -47,5 +47,5 @@ export interface TopHit {
     kind: string;
     ordered_alpha_key_with_id: string;
     previous_company_names: PreviousCompanyNames[];
-    matched_previous_company_names: MatchedPreviousCompanyNames[];
+    matched_previous_company_names: MatchedPreviousCompanyNames;
 }

--- a/test/services/search/dissolved-search/service.spec.ts
+++ b/test/services/search/dissolved-search/service.spec.ts
@@ -33,13 +33,12 @@ const mockResponseBody : CompaniesResource = ({
                     name: "old name"
                 },
             ],
-            matched_previous_company_names: [
+            matched_previous_company_name:
                 {
                     ceased_on: (new Date("19910212")),
                     effective_from: (new Date("19910212")),
                     name: "old name"
                 }
-            ]
         }
     ],
     kind: "kind",
@@ -64,13 +63,12 @@ const mockResponseBody : CompaniesResource = ({
                 name: "old name"
             }
         ],
-        matched_previous_company_names: [
+        matched_previous_company_name:
             {
                 ceased_on: (new Date("19910212")),
                 effective_from: (new Date("19910212")),
                 name: "old name"
             }
-        ]
     },
     hits: 20
 });
@@ -134,9 +132,9 @@ describe("create a dissolved search GET", () => {
         expect(item.previous_company_names[0].ceased_on).to.equal(mockItem.previous_company_names[0].ceased_on);
         expect(item.previous_company_names[0].effective_from).to.equal(mockItem.previous_company_names[0].effective_from);
         expect(item.previous_company_names[0].name).to.equal(mockItem.previous_company_names[0].name);
-        expect(item.matched_previous_company_names[0].ceased_on).to.equal(mockItem.matched_previous_company_names[0].ceased_on);
-        expect(item.matched_previous_company_names[0].effective_from).to.equal(mockItem.matched_previous_company_names[0].effective_from);
-        expect(item.matched_previous_company_names[0].name).to.equal(mockItem.matched_previous_company_names[0].name);
+        expect(item.matched_previous_company_name.ceased_on).to.equal(mockItem.matched_previous_company_name.ceased_on);
+        expect(item.matched_previous_company_name.effective_from).to.equal(mockItem.matched_previous_company_name.effective_from);
+        expect(item.matched_previous_company_name.name).to.equal(mockItem.matched_previous_company_name.name);
         expect(data.resource.kind).to.equal(mockResponseBody.kind);
         expect(data.resource.top_hit.registered_office_address.address_line_1).to.equal(mockResponseBody.top_hit.registered_office_address.address_line_1);
         expect(data.resource.top_hit.registered_office_address.address_line_2).to.equal(mockResponseBody.top_hit.registered_office_address.address_line_2);
@@ -151,9 +149,9 @@ describe("create a dissolved search GET", () => {
         expect(data.resource.top_hit.previous_company_names[0].ceased_on).to.equal(mockResponseBody.top_hit.previous_company_names[0].ceased_on);
         expect(data.resource.top_hit.previous_company_names[0].effective_from).to.equal(mockResponseBody.top_hit.previous_company_names[0].effective_from);
         expect(data.resource.top_hit.previous_company_names[0].name).to.equal(mockResponseBody.top_hit.previous_company_names[0].name);
-        expect(data.resource.top_hit.matched_previous_company_names[0].ceased_on).to.equal(mockResponseBody.top_hit.matched_previous_company_names[0].ceased_on);
-        expect(data.resource.top_hit.matched_previous_company_names[0].effective_from).to.equal(mockResponseBody.top_hit.matched_previous_company_names[0].effective_from);
-        expect(data.resource.top_hit.matched_previous_company_names[0].name).to.equal(mockResponseBody.top_hit.matched_previous_company_names[0].name);
+        expect(data.resource.top_hit.matched_previous_company_name.ceased_on).to.equal(mockResponseBody.top_hit.matched_previous_company_name.ceased_on);
+        expect(data.resource.top_hit.matched_previous_company_name.effective_from).to.equal(mockResponseBody.top_hit.matched_previous_company_name.effective_from);
+        expect(data.resource.top_hit.matched_previous_company_name.name).to.equal(mockResponseBody.top_hit.matched_previous_company_name.name);
         expect(data.resource.hits).to.equal(mockResponseBody.hits);
     });
 });

--- a/test/services/search/dissolved-search/service.spec.ts
+++ b/test/services/search/dissolved-search/service.spec.ts
@@ -31,7 +31,7 @@ const mockResponseBody : CompaniesResource = ({
                     ceased_on: (new Date("19910212")),
                     effective_from: (new Date("19910212")),
                     name: "old name"
-                },
+                }
             ],
             matched_previous_company_name:
                 {

--- a/test/services/search/dissolved-search/service.spec.ts
+++ b/test/services/search/dissolved-search/service.spec.ts
@@ -31,6 +31,13 @@ const mockResponseBody : CompaniesResource = ({
                     ceased_on: (new Date("19910212")),
                     effective_from: (new Date("19910212")),
                     name: "old name"
+                },
+            ],
+            matched_previous_company_names: [
+                {
+                    ceased_on: (new Date("19910212")),
+                    effective_from: (new Date("19910212")),
+                    name: "old name"
                 }
             ]
         }
@@ -51,6 +58,13 @@ const mockResponseBody : CompaniesResource = ({
         kind: "kind",
         ordered_alpha_key_with_id: "testcompany:0000789",
         previous_company_names: [
+            {
+                ceased_on: (new Date("19910212")),
+                effective_from: (new Date("19910212")),
+                name: "old name"
+            }
+        ],
+        matched_previous_company_names: [
             {
                 ceased_on: (new Date("19910212")),
                 effective_from: (new Date("19910212")),
@@ -120,6 +134,9 @@ describe("create a dissolved search GET", () => {
         expect(item.previous_company_names[0].ceased_on).to.equal(mockItem.previous_company_names[0].ceased_on);
         expect(item.previous_company_names[0].effective_from).to.equal(mockItem.previous_company_names[0].effective_from);
         expect(item.previous_company_names[0].name).to.equal(mockItem.previous_company_names[0].name);
+        expect(item.matched_previous_company_names[0].ceased_on).to.equal(mockItem.matched_previous_company_names[0].ceased_on);
+        expect(item.matched_previous_company_names[0].effective_from).to.equal(mockItem.matched_previous_company_names[0].effective_from);
+        expect(item.matched_previous_company_names[0].name).to.equal(mockItem.matched_previous_company_names[0].name);
         expect(data.resource.kind).to.equal(mockResponseBody.kind);
         expect(data.resource.top_hit.registered_office_address.address_line_1).to.equal(mockResponseBody.top_hit.registered_office_address.address_line_1);
         expect(data.resource.top_hit.registered_office_address.address_line_2).to.equal(mockResponseBody.top_hit.registered_office_address.address_line_2);
@@ -134,6 +151,9 @@ describe("create a dissolved search GET", () => {
         expect(data.resource.top_hit.previous_company_names[0].ceased_on).to.equal(mockResponseBody.top_hit.previous_company_names[0].ceased_on);
         expect(data.resource.top_hit.previous_company_names[0].effective_from).to.equal(mockResponseBody.top_hit.previous_company_names[0].effective_from);
         expect(data.resource.top_hit.previous_company_names[0].name).to.equal(mockResponseBody.top_hit.previous_company_names[0].name);
+        expect(data.resource.top_hit.matched_previous_company_names[0].ceased_on).to.equal(mockResponseBody.top_hit.matched_previous_company_names[0].ceased_on);
+        expect(data.resource.top_hit.matched_previous_company_names[0].effective_from).to.equal(mockResponseBody.top_hit.matched_previous_company_names[0].effective_from);
+        expect(data.resource.top_hit.matched_previous_company_names[0].name).to.equal(mockResponseBody.top_hit.matched_previous_company_names[0].name);
         expect(data.resource.hits).to.equal(mockResponseBody.hits);
     });
 });


### PR DESCRIPTION
Added in the matched_previous_name type, added it to items and the top_hit as well as amended the tests

Resolves: BI-8365