### PR TITLE
NCS-642 Put Transaction fix to remove response mapping

### DIFF
--- a/src/services/transaction/service.ts
+++ b/src/services/transaction/service.ts
@@ -44,37 +44,25 @@ export default class TransactionService {
      *
      * @param replacment transaction
      */
-    public async putTransaction (transaction: Transaction): Promise<ApiResponse<Transaction>|ApiErrorResponse> {
-        if (transaction.id) {
-            const url = "/transactions/" + transaction.id
+    public async putTransaction (transaction: Transaction): Promise<ApiResponse<Transaction> | ApiErrorResponse> {
+        const url = "/transactions/" + transaction.id
 
-            const transactionResource: TransactionResource = this.mapToResource(transaction);
-            const resp = await this.client.httpPut(url, transactionResource);
+        const transactionResource: TransactionResource = this.mapToResource(transaction);
+        const resp = await this.client.httpPut(url, transactionResource);
 
-            if (resp.error) {
-                return {
-                    httpStatusCode: resp.status,
-                    errors: [resp.error]
-                };
-            }
-
-            const resource: ApiResponse<Transaction> = {
-                headers: resp.headers,
-                httpStatusCode: resp.status
+        if (resp.error) {
+            return {
+                httpStatusCode: resp.status,
+                errors: [resp.error]
             };
-
-            // cast the response body to the expected type
-            const body: TransactionResource = resp.body as TransactionResource;
-
-            this.populateResource(resource, body);
-
-            return resource;
         }
 
-        return {
-            httpStatusCode: 400,
-            errors: [{ error: "Cannot update transaction - id not found" }]
+        const resource: ApiResponse<Transaction> = {
+            headers: resp.headers,
+            httpStatusCode: resp.status
         };
+
+        return resource;
     }
 
     private populateResource (resource:Resource<Transaction>, body:TransactionResource) {

--- a/test/services/transaction/service.spec.ts
+++ b/test/services/transaction/service.spec.ts
@@ -113,23 +113,11 @@ describe("transaction", () => {
     });
 
     it("put returns successful response", async () => {
-        const mockResponseBody : TransactionResource = ({
-            id: "12345678",
-            company_name: "HELLO LTD",
-            company_number: "88",
-            links: {
-                self: "/self"
-            },
-            reference: "ref",
-            description: "desc"
-        });
-
         const mockPutResponse = {
             headers: {
                 "X-Payment-Required": "http://link-to-payment"
             },
-            status: 202,
-            body: mockResponseBody
+            status: 202
         };
 
         sinon.stub(requestClient, "httpPut").resolves(mockPutResponse);
@@ -139,11 +127,6 @@ describe("transaction", () => {
         expect(data.httpStatusCode).to.equal(202);
         const castedData: ApiResponse<Transaction> = data as ApiResponse<Transaction>;
         expect(castedData.headers["X-Payment-Required"]).to.equal("http://link-to-payment");
-        expect(castedData.resource.companyName).to.equal(mockResponseBody.company_name);
-        expect(castedData.resource.companyNumber).to.equal(mockResponseBody.company_number);
-        expect(castedData.resource.links.self).to.equal(mockResponseBody.links.self);
-        expect(castedData.resource.reference).to.equal(mockResponseBody.reference);
-        expect(castedData.resource.description).to.equal(mockResponseBody.description);
     });
 
     it("put returns an error response on failure", async () => {
@@ -159,13 +142,5 @@ describe("transaction", () => {
         expect(data.httpStatusCode).to.equal(422);
         const castedData: ApiErrorResponse = data;
         expect(castedData.errors[0]).to.equal("Unprocessable Entity");
-    });
-
-    it("put returns an error response if id is not present", async () => {
-        const transaction: TransactionService = new TransactionService(requestClient);
-        const data = await transaction.putTransaction({} as Transaction);
-        expect(data.httpStatusCode).to.equal(400);
-        const castedData: ApiErrorResponse = data;
-        expect(castedData.errors[0].error).to.equal("Cannot update transaction - id not found");
     });
 });


### PR DESCRIPTION
The transaction putTransaction api call doesn't return a body so it was crashing when trying to map the body in the response. Removed the call to map the body in the response.