### PR TITLE
NCS-681 Add made up to date to Confirmation Statement types and mapping

### DIFF
--- a/src/services/confirmation-statement/service.ts
+++ b/src/services/confirmation-statement/service.ts
@@ -279,6 +279,7 @@ export default class {
 
     private mapToConfirmationStatementSubmissionData (dataResource: ConfirmationStatementSubmissionDataResource): ConfirmationStatementSubmissionData {
         return {
+            confirmationStatementMadeUpToDate: dataResource.confirmation_statement_made_up_to_date,
             ...(dataResource.persons_significant_control_data && { personsSignificantControlData: this.mapToPersonsOfSignificantControlData(dataResource.persons_significant_control_data) }),
             ...(dataResource.statement_of_capital_data && { statementOfCapitalData: this.mapToStatementOfCapitalData(dataResource.statement_of_capital_data) }),
             ...(dataResource.sic_code_data && { sicCodeData: this.mapToSicCodeData(dataResource.sic_code_data) }),
@@ -292,6 +293,7 @@ export default class {
 
     private mapToConfirmationStatementSubmissionDataResource (data: ConfirmationStatementSubmissionData): ConfirmationStatementSubmissionDataResource {
         return {
+            confirmation_statement_made_up_to_date: data.confirmationStatementMadeUpToDate,
             ...(data.personsSignificantControlData && { persons_significant_control_data: this.mapToPersonsOfSignificantControlDataResource(data.personsSignificantControlData) }),
             ...(data.statementOfCapitalData && { statement_of_capital_data: this.mapToStatementOfCapitalDataResource(data.statementOfCapitalData) }),
             ...(data.sicCodeData && { sic_code_data: this.mapToSicCodeDataResource(data.sicCodeData) }),

--- a/src/services/confirmation-statement/types.ts
+++ b/src/services/confirmation-statement/types.ts
@@ -15,24 +15,26 @@ export interface ConfirmationStatementSubmissionResource {
 }
 
 export interface ConfirmationStatementSubmissionDataResource {
-    persons_significant_control_data?: PersonsOfSignificantControlDataResource,
-    statement_of_capital_data?: StatementOfCapitalDataResource,
-    sic_code_data?: SicCodeDataResource,
-    registered_office_address_data?: RegisteredOfficeAddressDataResource,
     active_director_details_data?: ActiveDirectorDetailsDataResource,
-    shareholder_data?: ShareholderDataResource,
+    confirmation_statement_made_up_to_date: string,
+    persons_significant_control_data?: PersonsOfSignificantControlDataResource,
     register_locations_data?: RegisterLocationsDataResource,
+    registered_office_address_data?: RegisteredOfficeAddressDataResource,
+    shareholder_data?: ShareholderDataResource,
+    sic_code_data?: SicCodeDataResource,
+    statement_of_capital_data?: StatementOfCapitalDataResource,
     trading_status_data?: TradingStatusDataResource
 }
 
 export interface ConfirmationStatementSubmissionData {
-    personsSignificantControlData?: PersonsOfSignificantControlData
-    statementOfCapitalData?: StatementOfCapitalData,
-    sicCodeData?: SicCodeData,
-    registeredOfficeAddressData?: RegisteredOfficeAddressData,
     activeDirectorDetailsData?: ActiveDirectorDetailsData,
-    shareholderData?: ShareholderData,
+    confirmationStatementMadeUpToDate: string,
+    personsSignificantControlData?: PersonsOfSignificantControlData,
+    registeredOfficeAddressData?: RegisteredOfficeAddressData,
     registerLocationsData?: RegisterLocationsData,
+    shareholderData?: ShareholderData,
+    sicCodeData?: SicCodeData,
+    statementOfCapitalData?: StatementOfCapitalData,
     tradingStatusData?: TradingStatusData
 }
 

--- a/test/services/confirmation-statement/confirmation.statement.mock.ts
+++ b/test/services/confirmation-statement/confirmation.statement.mock.ts
@@ -54,6 +54,7 @@ export const mockStatementOfCapital: StatementOfCapitalResource = {
 export const mockConfirmationStatementSubmission: ConfirmationStatementSubmission = {
     id: "abc",
     data: {
+        confirmationStatementMadeUpToDate: "2021-09-10",
         personsSignificantControlData: {
             sectionStatus: SectionStatus.CONFIRMED,
             personsOfSignificantControl: []
@@ -204,6 +205,7 @@ export const mockRegisterLocationsList: RegisterLocationResource[] = [
 export const mockConfirmationStatementSubmissionResource: ConfirmationStatementSubmissionResource = {
     id: "abc",
     data: {
+        confirmation_statement_made_up_to_date: "2021-09-10",
         persons_significant_control_data: {
             section_status: SectionStatus.CONFIRMED,
             persons_of_significant_control: []
@@ -248,7 +250,9 @@ export const mockConfirmationStatementSubmissionResourceNoData: ConfirmationStat
 
 export const mockConfirmationStatementSubmissionResourceEmptyData: ConfirmationStatementSubmissionResource = {
     id: "abc",
-    data: { },
+    data: {
+        confirmation_statement_made_up_to_date: "2021-09-10"
+    },
     links: {
         self: "self/link"
     }
@@ -257,6 +261,7 @@ export const mockConfirmationStatementSubmissionResourceEmptyData: ConfirmationS
 export const mockConfirmationStatementSubmissionResourceNoSOC: ConfirmationStatementSubmissionResource = {
     id: "abc",
     data: {
+        confirmation_statement_made_up_to_date: "2021-09-10",
         statement_of_capital_data: {
             section_status: SectionStatus.CONFIRMED
         }

--- a/test/services/confirmation-statement/confirmation.statement.spec.ts
+++ b/test/services/confirmation-statement/confirmation.statement.spec.ts
@@ -151,6 +151,7 @@ describe("Update confirmation statement POST", () => {
         const updatedConfirmationStatement = data.resource;
         const mockSubmission = mockValues.mockConfirmationStatementSubmissionResource;
         expect(updatedConfirmationStatement.id).to.equal(mockSubmission.id);
+        expect(updatedConfirmationStatement.data.confirmationStatementMadeUpToDate).to.equal(mockSubmission.data.confirmation_statement_made_up_to_date);
         expect(updatedConfirmationStatement.data.statementOfCapitalData.sectionStatus).to.equal(mockSubmission.data.statement_of_capital_data.section_status);
         expect(updatedConfirmationStatement.data.statementOfCapitalData.statementOfCapital.classOfShares).to.equal(mockSubmission.data.statement_of_capital_data.statement_of_capital.class_of_shares);
         expect(updatedConfirmationStatement.data.sicCodeData.sectionStatus).to.equal(mockSubmission.data.sic_code_data.section_status);
@@ -342,12 +343,14 @@ describe("confirmation statement submission GET", () => {
         const data: Resource<ConfirmationStatementSubmission> =
             await csService.getConfirmationStatementSubmission(TRANSACTION_ID, CONFIRMATION_STATEMENT_ID) as Resource<ConfirmationStatementSubmission>;
 
+        const mockResource = mockValues.mockConfirmationStatementSubmissionResource;
         expect(data.httpStatusCode).to.equal(200);
-        expect(data.resource.id).to.equal(mockValues.mockConfirmationStatementSubmissionResource.id);
-        expect(data.resource.links).to.equal(mockValues.mockConfirmationStatementSubmissionResource.links)
-        expect(data.resource.data.statementOfCapitalData.sectionStatus).to.equal(mockValues.mockConfirmationStatementSubmissionResource.data.statement_of_capital_data.section_status);
+        expect(data.resource.id).to.equal(mockResource.id);
+        expect(data.resource.links).to.equal(mockResource.links);
+        expect(data.resource.data.confirmationStatementMadeUpToDate).to.equal(mockResource.data.confirmation_statement_made_up_to_date);
+        expect(data.resource.data.statementOfCapitalData.sectionStatus).to.equal(mockResource.data.statement_of_capital_data.section_status);
         const statementOfCapital: StatementOfCapital = data.resource.data.statementOfCapitalData.statementOfCapital;
-        const mockStatementOfCapital: StatementOfCapitalResource = mockValues.mockConfirmationStatementSubmissionResource.data.statement_of_capital_data.statement_of_capital
+        const mockStatementOfCapital: StatementOfCapitalResource = mockResource.data.statement_of_capital_data.statement_of_capital
         expect(statementOfCapital.aggregateNominalValue).to.equal(mockStatementOfCapital.aggregate_nominal_value);
         expect(statementOfCapital.classOfShares).to.equal(mockStatementOfCapital.class_of_shares);
         expect(statementOfCapital.currency).to.equal(mockStatementOfCapital.currency);
@@ -368,18 +371,6 @@ describe("confirmation statement submission GET", () => {
         expect(data.resource.id).to.equal(mockValues.mockConfirmationStatementSubmissionResourceNoData.id);
         expect(data.resource.links).to.equal(mockValues.mockConfirmationStatementSubmissionResourceNoData.links)
         expect(data.resource.data).to.equal(undefined);
-    });
-
-    it("should return confirmation statement submission object with empty data", async () => {
-        sinon.stub(mockValues.requestClient, "httpGet").resolves({ status: 200, body: mockValues.mockConfirmationStatementSubmissionResourceEmptyData });
-        const csService: ConfirmationStatementService = new ConfirmationStatementService(mockValues.requestClient);
-        const data: Resource<ConfirmationStatementSubmission> =
-            await csService.getConfirmationStatementSubmission(TRANSACTION_ID, CONFIRMATION_STATEMENT_ID) as Resource<ConfirmationStatementSubmission>;
-
-        expect(data.httpStatusCode).to.equal(200);
-        expect(data.resource.id).to.equal(mockValues.mockConfirmationStatementSubmissionResourceEmptyData.id);
-        expect(data.resource.links).to.equal(mockValues.mockConfirmationStatementSubmissionResourceEmptyData.links)
-        expect(data.resource.data).to.deep.equal(mockValues.mockConfirmationStatementSubmissionResourceEmptyData.data);
     });
 
     it("should return confirmation statement submission object with no statement of capital", async () => {
@@ -404,52 +395,52 @@ describe("confirmation statement submission GET", () => {
         expect(data.httpStatusCode).to.equal(404);
         expect(data.errors[0]).to.equal("No confirmation statement submission found");
     });
+});
 
-    describe("getNextMadeUpToDate tests", () => {
-        it("Should not map optional fields when filing is due", async () => {
-            sinon.stub(mockValues.requestClient, "httpGet").resolves({ status: 200, body: mockValues.mockNextMadeUpToDateResourceIsDue });
-            const csService: ConfirmationStatementService = new ConfirmationStatementService(mockValues.requestClient);
-            const response: Resource<NextMadeUpToDate> = await csService.getNextMadeUpToDate(COMPANY_NUMBER) as Resource<NextMadeUpToDate>;
-            const nextMadeUpToDate: NextMadeUpToDate = response.resource;
+describe("getNextMadeUpToDate tests", () => {
+    it("Should not map optional fields when filing is due", async () => {
+        sinon.stub(mockValues.requestClient, "httpGet").resolves({ status: 200, body: mockValues.mockNextMadeUpToDateResourceIsDue });
+        const csService: ConfirmationStatementService = new ConfirmationStatementService(mockValues.requestClient);
+        const response: Resource<NextMadeUpToDate> = await csService.getNextMadeUpToDate(COMPANY_NUMBER) as Resource<NextMadeUpToDate>;
+        const nextMadeUpToDate: NextMadeUpToDate = response.resource;
 
-            expect(response.httpStatusCode).to.equal(200);
-            expect(nextMadeUpToDate.currentNextMadeUpToDate).to.equal(mockValues.mockNextMadeUpToDateResourceIsDue.current_next_made_up_to_date);
-            expect(nextMadeUpToDate.isDue).to.equal(mockValues.mockNextMadeUpToDateResourceIsDue.is_due);
-            expect(nextMadeUpToDate.newNextMadeUpToDate).to.be.undefined;
-        })
+        expect(response.httpStatusCode).to.equal(200);
+        expect(nextMadeUpToDate.currentNextMadeUpToDate).to.equal(mockValues.mockNextMadeUpToDateResourceIsDue.current_next_made_up_to_date);
+        expect(nextMadeUpToDate.isDue).to.equal(mockValues.mockNextMadeUpToDateResourceIsDue.is_due);
+        expect(nextMadeUpToDate.newNextMadeUpToDate).to.be.undefined;
+    })
 
-        it("Should map optional fields when filing is not due", async () => {
-            sinon.stub(mockValues.requestClient, "httpGet").resolves({ status: 200, body: mockValues.mockNextMadeUpToDateResourceIsNotDue });
-            const csService: ConfirmationStatementService = new ConfirmationStatementService(mockValues.requestClient);
-            const response: Resource<NextMadeUpToDate> = await csService.getNextMadeUpToDate(COMPANY_NUMBER) as Resource<NextMadeUpToDate>;
-            const nextMadeUpToDate: NextMadeUpToDate = response.resource;
+    it("Should map optional fields when filing is not due", async () => {
+        sinon.stub(mockValues.requestClient, "httpGet").resolves({ status: 200, body: mockValues.mockNextMadeUpToDateResourceIsNotDue });
+        const csService: ConfirmationStatementService = new ConfirmationStatementService(mockValues.requestClient);
+        const response: Resource<NextMadeUpToDate> = await csService.getNextMadeUpToDate(COMPANY_NUMBER) as Resource<NextMadeUpToDate>;
+        const nextMadeUpToDate: NextMadeUpToDate = response.resource;
 
-            expect(response.httpStatusCode).to.equal(200);
-            expect(nextMadeUpToDate.currentNextMadeUpToDate).to.equal(mockValues.mockNextMadeUpToDateResourceIsNotDue.current_next_made_up_to_date);
-            expect(nextMadeUpToDate.isDue).to.equal(mockValues.mockNextMadeUpToDateResourceIsNotDue.is_due);
-            expect(nextMadeUpToDate.newNextMadeUpToDate).not.to.be.undefined;
-            expect(nextMadeUpToDate.newNextMadeUpToDate).to.equal(mockValues.mockNextMadeUpToDateResourceIsNotDue.new_next_made_up_to_date);
-        })
+        expect(response.httpStatusCode).to.equal(200);
+        expect(nextMadeUpToDate.currentNextMadeUpToDate).to.equal(mockValues.mockNextMadeUpToDateResourceIsNotDue.current_next_made_up_to_date);
+        expect(nextMadeUpToDate.isDue).to.equal(mockValues.mockNextMadeUpToDateResourceIsNotDue.is_due);
+        expect(nextMadeUpToDate.newNextMadeUpToDate).not.to.be.undefined;
+        expect(nextMadeUpToDate.newNextMadeUpToDate).to.equal(mockValues.mockNextMadeUpToDateResourceIsNotDue.new_next_made_up_to_date);
+    })
 
-        it("Should not map optional fields when no cs found in company profile", async () => {
-            sinon.stub(mockValues.requestClient, "httpGet").resolves({ status: 200, body: mockValues.mockNextMadeUpToDateResourceNoCs });
-            const csService: ConfirmationStatementService = new ConfirmationStatementService(mockValues.requestClient);
-            const response: Resource<NextMadeUpToDate> = await csService.getNextMadeUpToDate(COMPANY_NUMBER) as Resource<NextMadeUpToDate>;
-            const nextMadeUpToDate: NextMadeUpToDate = response.resource;
+    it("Should not map optional fields when no cs found in company profile", async () => {
+        sinon.stub(mockValues.requestClient, "httpGet").resolves({ status: 200, body: mockValues.mockNextMadeUpToDateResourceNoCs });
+        const csService: ConfirmationStatementService = new ConfirmationStatementService(mockValues.requestClient);
+        const response: Resource<NextMadeUpToDate> = await csService.getNextMadeUpToDate(COMPANY_NUMBER) as Resource<NextMadeUpToDate>;
+        const nextMadeUpToDate: NextMadeUpToDate = response.resource;
 
-            expect(response.httpStatusCode).to.equal(200);
-            expect(nextMadeUpToDate.currentNextMadeUpToDate).to.be.null;
-            expect(nextMadeUpToDate.isDue).to.be.undefined
-            expect(nextMadeUpToDate.newNextMadeUpToDate).to.be.undefined;
-        })
+        expect(response.httpStatusCode).to.equal(200);
+        expect(nextMadeUpToDate.currentNextMadeUpToDate).to.be.null;
+        expect(nextMadeUpToDate.isDue).to.be.undefined
+        expect(nextMadeUpToDate.newNextMadeUpToDate).to.be.undefined;
+    })
 
-        it("Should return an error when api response status >= 400", async () => {
-            sinon.stub(mockValues.requestClient, "httpGet").resolves({ status: 404, error: "Not Found" });
-            const csService: ConfirmationStatementService = new ConfirmationStatementService(mockValues.requestClient);
-            const response: ApiErrorResponse = await csService.getNextMadeUpToDate(COMPANY_NUMBER) as ApiErrorResponse;
+    it("Should return an error when api response status >= 400", async () => {
+        sinon.stub(mockValues.requestClient, "httpGet").resolves({ status: 404, error: "Not Found" });
+        const csService: ConfirmationStatementService = new ConfirmationStatementService(mockValues.requestClient);
+        const response: ApiErrorResponse = await csService.getNextMadeUpToDate(COMPANY_NUMBER) as ApiErrorResponse;
 
-            expect(response.httpStatusCode).to.equal(404);
-            expect(response.errors[0]).to.equal("Not Found");
-        })
+        expect(response.httpStatusCode).to.equal(404);
+        expect(response.errors[0]).to.equal("Not Found");
     })
 });


### PR DESCRIPTION
adding the made up to date to the ConfirmationSubmission types and including it in the mapping of data between api resource and type.