### PR TITLE
NCS-681 Making confirmation statement data mandatory

### DIFF
--- a/src/services/confirmation-statement/service.ts
+++ b/src/services/confirmation-statement/service.ts
@@ -258,7 +258,7 @@ export default class {
     private mapToConfirmationStatementSubmission (apiResource: ConfirmationStatementSubmissionResource): ConfirmationStatementSubmission {
         return {
             id: apiResource.id,
-            ...(apiResource.data && { data: this.mapToConfirmationStatementSubmissionData(apiResource.data) }),
+            data: this.mapToConfirmationStatementSubmissionData(apiResource.data),
             links: apiResource.links
         }
     }
@@ -266,7 +266,7 @@ export default class {
     private mapToConfirmationStatementSubmissionResource (submission: ConfirmationStatementSubmission): ConfirmationStatementSubmissionResource {
         return {
             id: submission.id,
-            ...(submission.data && { data: this.mapToConfirmationStatementSubmissionDataResource(submission.data) }),
+            data: this.mapToConfirmationStatementSubmissionDataResource(submission.data),
             links: submission.links
         }
     }

--- a/src/services/confirmation-statement/types.ts
+++ b/src/services/confirmation-statement/types.ts
@@ -1,6 +1,6 @@
 export interface ConfirmationStatementSubmission {
     id: string,
-    data?: ConfirmationStatementSubmissionData,
+    data: ConfirmationStatementSubmissionData,
     links: {
         self: string,
     },
@@ -8,7 +8,7 @@ export interface ConfirmationStatementSubmission {
 
 export interface ConfirmationStatementSubmissionResource {
     id: string,
-    data?: ConfirmationStatementSubmissionDataResource,
+    data: ConfirmationStatementSubmissionDataResource,
     links: {
         self: string,
     },

--- a/test/services/confirmation-statement/confirmation.statement.mock.ts
+++ b/test/services/confirmation-statement/confirmation.statement.mock.ts
@@ -241,23 +241,6 @@ export const mockConfirmationStatementSubmissionResource: ConfirmationStatementS
     }
 };
 
-export const mockConfirmationStatementSubmissionResourceNoData: ConfirmationStatementSubmissionResource = {
-    id: "abc",
-    links: {
-        self: "self/link"
-    }
-};
-
-export const mockConfirmationStatementSubmissionResourceEmptyData: ConfirmationStatementSubmissionResource = {
-    id: "abc",
-    data: {
-        confirmation_statement_made_up_to_date: "2021-09-10"
-    },
-    links: {
-        self: "self/link"
-    }
-};
-
 export const mockConfirmationStatementSubmissionResourceNoSOC: ConfirmationStatementSubmissionResource = {
     id: "abc",
     data: {

--- a/test/services/confirmation-statement/confirmation.statement.spec.ts
+++ b/test/services/confirmation-statement/confirmation.statement.spec.ts
@@ -361,18 +361,6 @@ describe("confirmation statement submission GET", () => {
         expect(statementOfCapital.totalNumberOfShares).to.equal(mockStatementOfCapital.total_number_of_shares);
     });
 
-    it("should return confirmation statement submission object without data", async () => {
-        sinon.stub(mockValues.requestClient, "httpGet").resolves({ status: 200, body: mockValues.mockConfirmationStatementSubmissionResourceNoData });
-        const csService: ConfirmationStatementService = new ConfirmationStatementService(mockValues.requestClient);
-        const data: Resource<ConfirmationStatementSubmission> =
-            await csService.getConfirmationStatementSubmission(TRANSACTION_ID, CONFIRMATION_STATEMENT_ID) as Resource<ConfirmationStatementSubmission>;
-
-        expect(data.httpStatusCode).to.equal(200);
-        expect(data.resource.id).to.equal(mockValues.mockConfirmationStatementSubmissionResourceNoData.id);
-        expect(data.resource.links).to.equal(mockValues.mockConfirmationStatementSubmissionResourceNoData.links)
-        expect(data.resource.data).to.equal(undefined);
-    });
-
     it("should return confirmation statement submission object with no statement of capital", async () => {
         sinon.stub(mockValues.requestClient, "httpGet").resolves({ status: 200, body: mockValues.mockConfirmationStatementSubmissionResourceNoSOC });
         const csService: ConfirmationStatementService = new ConfirmationStatementService(mockValues.requestClient);
@@ -408,7 +396,7 @@ describe("getNextMadeUpToDate tests", () => {
         expect(nextMadeUpToDate.currentNextMadeUpToDate).to.equal(mockValues.mockNextMadeUpToDateResourceIsDue.current_next_made_up_to_date);
         expect(nextMadeUpToDate.isDue).to.equal(mockValues.mockNextMadeUpToDateResourceIsDue.is_due);
         expect(nextMadeUpToDate.newNextMadeUpToDate).to.be.undefined;
-    })
+    });
 
     it("Should map optional fields when filing is not due", async () => {
         sinon.stub(mockValues.requestClient, "httpGet").resolves({ status: 200, body: mockValues.mockNextMadeUpToDateResourceIsNotDue });
@@ -421,7 +409,7 @@ describe("getNextMadeUpToDate tests", () => {
         expect(nextMadeUpToDate.isDue).to.equal(mockValues.mockNextMadeUpToDateResourceIsNotDue.is_due);
         expect(nextMadeUpToDate.newNextMadeUpToDate).not.to.be.undefined;
         expect(nextMadeUpToDate.newNextMadeUpToDate).to.equal(mockValues.mockNextMadeUpToDateResourceIsNotDue.new_next_made_up_to_date);
-    })
+    });
 
     it("Should not map optional fields when no cs found in company profile", async () => {
         sinon.stub(mockValues.requestClient, "httpGet").resolves({ status: 200, body: mockValues.mockNextMadeUpToDateResourceNoCs });
@@ -433,7 +421,7 @@ describe("getNextMadeUpToDate tests", () => {
         expect(nextMadeUpToDate.currentNextMadeUpToDate).to.be.null;
         expect(nextMadeUpToDate.isDue).to.be.undefined
         expect(nextMadeUpToDate.newNextMadeUpToDate).to.be.undefined;
-    })
+    });
 
     it("Should return an error when api response status >= 400", async () => {
         sinon.stub(mockValues.requestClient, "httpGet").resolves({ status: 404, error: "Not Found" });
@@ -442,5 +430,5 @@ describe("getNextMadeUpToDate tests", () => {
 
         expect(response.httpStatusCode).to.equal(404);
         expect(response.errors[0]).to.equal("Not Found");
-    })
+    });
 });


### PR DESCRIPTION
Making data block mandatory as it should be populated with a made up to date when confirmation statement record is created.