### PR TITLE
fix company status url builder advanced search

### DIFF
--- a/src/services/search/advanced-search/service.ts
+++ b/src/services/search/advanced-search/service.ts
@@ -50,7 +50,7 @@ export default class AdvancedSearchService {
         }
 
         if (companyStatus !== null) {
-            buildEnhancedSearchURL.append(COMPANY_STATUS_QUERY, companyNameIncludes)
+            buildEnhancedSearchURL.append(COMPANY_STATUS_QUERY, companyStatus);
         }
 
         if (companyType !== null) {


### PR DESCRIPTION
Small fix to use the correct argument value for company status for advanced search

