### PR TITLE
NCS-828 Add officerType to ActiveOfficerDetails object

### DIFF
--- a/src/services/confirmation-statement/service.ts
+++ b/src/services/confirmation-statement/service.ts
@@ -489,7 +489,13 @@ export default class {
             countryOfResidence: apiResource.country_of_residence,
             ...(apiResource.service_address && { serviceAddress: this.mapToAddress(apiResource.service_address) }),
             ...(apiResource.residential_address && { residentialAddress: this.mapToAddress(apiResource.residential_address) }),
-            officerType: apiResource.officer_type
+            corporate: apiResource.corporate,
+            role: apiResource.role,
+            placeRegistered: apiResource.place_registered,
+            registrationNumber: apiResource.registration_number,
+            lawGoverned: apiResource.law_governed,
+            legalForm: apiResource.legal_form,
+            identificationType: apiResource.identification_type
         }
     }
 

--- a/src/services/confirmation-statement/service.ts
+++ b/src/services/confirmation-statement/service.ts
@@ -489,7 +489,7 @@ export default class {
             countryOfResidence: apiResource.country_of_residence,
             ...(apiResource.service_address && { serviceAddress: this.mapToAddress(apiResource.service_address) }),
             ...(apiResource.residential_address && { residentialAddress: this.mapToAddress(apiResource.residential_address) }),
-            corporate: apiResource.corporate,
+            isCorporate: apiResource.is_corporate,
             role: apiResource.role,
             placeRegistered: apiResource.place_registered,
             registrationNumber: apiResource.registration_number,

--- a/src/services/confirmation-statement/service.ts
+++ b/src/services/confirmation-statement/service.ts
@@ -488,7 +488,8 @@ export default class {
             dateOfAppointment: apiResource.date_of_appointment,
             countryOfResidence: apiResource.country_of_residence,
             ...(apiResource.service_address && { serviceAddress: this.mapToAddress(apiResource.service_address) }),
-            ...(apiResource.residential_address && { residentialAddress: this.mapToAddress(apiResource.residential_address) })
+            ...(apiResource.residential_address && { residentialAddress: this.mapToAddress(apiResource.residential_address) }),
+            officerType: apiResource.officer_type
         }
     }
 

--- a/src/services/confirmation-statement/types.ts
+++ b/src/services/confirmation-statement/types.ts
@@ -188,11 +188,11 @@ export interface ActiveOfficerDetailsResource {
     residential_address: AddressResource;
     is_corporate: boolean;
     role: string;
-    place_registered: string;
-    registration_number: string;
-    law_governed: string;
-    legal_form: string;
-    identification_type: string;
+    place_registered?: string;
+    registration_number?: string;
+    law_governed?: string;
+    legal_form?: string;
+    identification_type?: string;
 }
 
 export interface RegisterLocation {

--- a/src/services/confirmation-statement/types.ts
+++ b/src/services/confirmation-statement/types.ts
@@ -166,7 +166,7 @@ export interface ActiveOfficerDetails {
     countryOfResidence: string;
     serviceAddress: Address;
     residentialAddress: Address;
-    corporate: boolean;
+    isCorporate: boolean;
     role: string;
     placeRegistered: string;
     registrationNumber: string;
@@ -186,7 +186,7 @@ export interface ActiveOfficerDetailsResource {
     country_of_residence: string;
     service_address: AddressResource;
     residential_address: AddressResource;
-    corporate: boolean;
+    is_corporate: boolean;
     role: string;
     place_registered: string;
     registration_number: string;

--- a/src/services/confirmation-statement/types.ts
+++ b/src/services/confirmation-statement/types.ts
@@ -166,7 +166,13 @@ export interface ActiveOfficerDetails {
     countryOfResidence: string;
     serviceAddress: Address;
     residentialAddress: Address;
-    officerType: string;
+    corporate: boolean;
+    role: string;
+    placeRegistered: string;
+    registrationNumber: string;
+    lawGoverned: string;
+    legalForm: string;
+    identificationType: string;
 }
 
 export interface ActiveOfficerDetailsResource {
@@ -180,7 +186,13 @@ export interface ActiveOfficerDetailsResource {
     country_of_residence: string;
     service_address: AddressResource;
     residential_address: AddressResource;
-    officer_type: string;
+    corporate: boolean;
+    role: string;
+    place_registered: string;
+    registration_number: string;
+    law_governed: string;
+    legal_form: string;
+    identification_type: string;
 }
 
 export interface RegisterLocation {

--- a/src/services/confirmation-statement/types.ts
+++ b/src/services/confirmation-statement/types.ts
@@ -166,6 +166,7 @@ export interface ActiveOfficerDetails {
     countryOfResidence: string;
     serviceAddress: Address;
     residentialAddress: Address;
+    officerType: string;
 }
 
 export interface ActiveOfficerDetailsResource {
@@ -179,6 +180,7 @@ export interface ActiveOfficerDetailsResource {
     country_of_residence: string;
     service_address: AddressResource;
     residential_address: AddressResource;
+    officer_type: string;
 }
 
 export interface RegisterLocation {

--- a/src/services/confirmation-statement/types.ts
+++ b/src/services/confirmation-statement/types.ts
@@ -168,11 +168,11 @@ export interface ActiveOfficerDetails {
     residentialAddress: Address;
     isCorporate: boolean;
     role: string;
-    placeRegistered: string;
-    registrationNumber: string;
-    lawGoverned: string;
-    legalForm: string;
-    identificationType: string;
+    placeRegistered?: string;
+    registrationNumber?: string;
+    lawGoverned?: string;
+    legalForm?: string;
+    identificationType?: string;
 }
 
 export interface ActiveOfficerDetailsResource {

--- a/test/services/confirmation-statement/confirmation.statement.mock.ts
+++ b/test/services/confirmation-statement/confirmation.statement.mock.ts
@@ -98,7 +98,8 @@ export const mockActiveOfficerDetails: ActiveOfficerDetailsResource = {
     date_of_appointment: "1 January 2009",
     country_of_residence: "Country",
     service_address: mockAddress1,
-    residential_address: mockAddress2
+    residential_address: mockAddress2,
+    officer_type: "NATURAL DIRECTOR"
 }
 
 export const mockPersonsWithSignificantControlList: PersonOfSignificantControlResource[] = [

--- a/test/services/confirmation-statement/confirmation.statement.mock.ts
+++ b/test/services/confirmation-statement/confirmation.statement.mock.ts
@@ -99,7 +99,13 @@ export const mockActiveOfficerDetails: ActiveOfficerDetailsResource = {
     country_of_residence: "Country",
     service_address: mockAddress1,
     residential_address: mockAddress2,
-    officer_type: "NATURAL DIRECTOR"
+    corporate: false,
+    role: "SECRETARY",
+    place_registered: "UNITED KINGDOM",
+    registration_number: "012345678",
+    law_governed: "INTERNATIONAL BUSINESS COMPANIES ACT 2000",
+    legal_form: "INTERNATIONAL BUSINESS COMPANY",
+    identification_type: "Y"
 }
 
 export const mockPersonsWithSignificantControlList: PersonOfSignificantControlResource[] = [

--- a/test/services/confirmation-statement/confirmation.statement.mock.ts
+++ b/test/services/confirmation-statement/confirmation.statement.mock.ts
@@ -99,7 +99,7 @@ export const mockActiveOfficerDetails: ActiveOfficerDetailsResource = {
     country_of_residence: "Country",
     service_address: mockAddress1,
     residential_address: mockAddress2,
-    corporate: false,
+    is_corporate: false,
     role: "SECRETARY",
     place_registered: "UNITED KINGDOM",
     registration_number: "012345678",


### PR DESCRIPTION
Add corporate identifier fields to ActiveOfficerDetails.

PS: ticket has been renamed NCS-828 -> [BI-9482](https://companieshouse.atlassian.net/browse/BI-9482).