### PR TITLE
BI-9543 Add liquidators details types and mappings

### DIFF
--- a/src/services/order/certificates/mapping.ts
+++ b/src/services/order/certificates/mapping.ts
@@ -272,7 +272,7 @@ export default class CertificateMapping {
         return Object.values(liquidatorsDetails).some((value) => value !== undefined) ? liquidatorsDetails : undefined;
     }
 
-    private static mapLiquidatorDetailsRequestToLiquidatorsDetailsResource(request: LiquidatorsDetailsRequest) : LiquidatorsDetailsResource {
+    private static mapLiquidatorDetailsRequestToLiquidatorsDetailsResource (request: LiquidatorsDetailsRequest) : LiquidatorsDetailsResource {
         const resource: LiquidatorsDetailsResource = {
             include_basic_information: request?.includeBasicInformation
         };

--- a/src/services/order/certificates/mapping.ts
+++ b/src/services/order/certificates/mapping.ts
@@ -57,7 +57,7 @@ export default class CertificateMapping {
                 this.mapPartnerDetailsRequestToPartnerDetailsResource(itemOptions.limitedPartnerDetails);
 
         const liquidatorsDetails =
-            this.mapLiquidatorDetailsRequestToLiquidatorsDetailsResource(itemOptions.includeLiquidatorsDetails);
+            this.mapLiquidatorDetailsRequestToLiquidatorsDetailsResource(itemOptions.liquidatorsDetails);
 
         return {
             customer_reference: certificateItemRequest.customerReference,

--- a/src/services/order/certificates/mapping.ts
+++ b/src/services/order/certificates/mapping.ts
@@ -1,6 +1,6 @@
 
 import {
-    CertificateItem, CertificateItemResource, ItemOptionsResource,
+    CertificateItem, CertificateItemResource,
     ItemCostsResource, CertificateItemPostRequest, CertificateItemRequestResource,
     ItemOptionsRequest, CertificateItemPatchRequest, DirectorOrSecretaryDetails, DirectorOrSecretaryDetailsResource,
     RegisteredOfficeAddressDetailsResource, RegisteredOfficeAddressDetails, DirectorOrSecretaryDetailsRequest,
@@ -21,7 +21,10 @@ import {
     PartnerDetails,
     PrincipalPlaceOfBusinessDetails,
     OrdinaryMemberDetails,
-    LimitedPartnerDetails
+    LimitedPartnerDetails,
+    LiquidatorsDetails,
+    LiquidatorsDetailsRequest,
+    LiquidatorsDetailsResource
 } from "./types";
 
 export default class CertificateMapping {
@@ -52,6 +55,10 @@ export default class CertificateMapping {
 
         const limitedPartnerDetails: LimitedPartnerDetailsResource =
                 this.mapPartnerDetailsRequestToPartnerDetailsResource(itemOptions.limitedPartnerDetails);
+
+        const liquidatorsDetails =
+            this.mapLiquidatorDetailsRequestToLiquidatorsDetailsResource(itemOptions.includeLiquidatorsDetails);
+
         return {
             customer_reference: certificateItemRequest.customerReference,
             company_number: certificateItemRequest.companyNumber,
@@ -75,14 +82,15 @@ export default class CertificateMapping {
                 registered_office_address_details: registeredOfficeAddressDetails,
                 secretary_details: secretaryDetails,
                 surname: itemOptions.surname,
-                company_type: itemOptions.companyType
+                company_type: itemOptions.companyType,
+                liquidators_details: liquidatorsDetails
             },
             quantity: certificateItemRequest.quantity
         };
     }
 
     public static mapCertificateItemResourceToCertificateItem (body: CertificateItemResource): CertificateItem {
-        const io = body.item_options as ItemOptionsResource;
+        const io = body.item_options;
 
         const directorDetails: DirectorOrSecretaryDetails =
                 this.mapDirectorOrSecretaryDetailsResourceToDirectorOrSecretaryDetails(io.director_details);
@@ -108,7 +116,9 @@ export default class CertificateMapping {
         const limitedPartnerDetails: LimitedPartnerDetails =
                 this.mapPartnerDetailsResourceToPartnerDetails(io.limited_partner_details);
 
-        const certificateItem: CertificateItem = {
+        const liquidatorsDetails = this.mapLiquidatorDetailsResourceToLiquidatorsDetails(io.liquidators_details);
+
+        return {
             companyName: body.company_name,
             companyNumber: body.company_number,
             customerReference: body.customer_reference,
@@ -143,7 +153,8 @@ export default class CertificateMapping {
                 principalPlaceOfBusinessDetails,
                 registeredOfficeAddressDetails,
                 secretaryDetails,
-                surname: io.surname
+                surname: io.surname,
+                liquidatorsDetails
             },
             kind: body.kind,
             links: {
@@ -153,9 +164,7 @@ export default class CertificateMapping {
             postalDelivery: body.postal_delivery,
             quantity: body.quantity,
             totalItemCost: body.total_item_cost
-        };
-        const cleanCertificateItem: CertificateItem = certificateItem;
-        return cleanCertificateItem;
+        }
     }
 
     private static mapDirectorOrSecretaryDetailsRequestDirectorOrSecretaryDetailsResource (
@@ -254,5 +263,19 @@ export default class CertificateMapping {
             includeBasicInformation: resource?.include_basic_information
         };
         return Object.values(partnerDetails).some((value) => value !== undefined) ? partnerDetails : undefined;
+    }
+
+    private static mapLiquidatorDetailsResourceToLiquidatorsDetails (resource: LiquidatorsDetailsResource): LiquidatorsDetails {
+        const liquidatorsDetails: LiquidatorsDetails = {
+            includeBasicInformation: resource?.include_basic_information
+        };
+        return Object.values(liquidatorsDetails).some((value) => value !== undefined) ? liquidatorsDetails : undefined;
+    }
+
+    private static mapLiquidatorDetailsRequestToLiquidatorsDetailsResource(request: LiquidatorsDetailsRequest) : LiquidatorsDetailsResource {
+        const resource: LiquidatorsDetailsResource = {
+            include_basic_information: request?.includeBasicInformation
+        };
+        return Object.values(resource).some((value) => value !== undefined) ? resource : undefined;
     }
 }

--- a/src/services/order/certificates/types.ts
+++ b/src/services/order/certificates/types.ts
@@ -49,6 +49,7 @@ export interface ItemOptionsResource {
     registered_office_address_details: RegisteredOfficeAddressDetailsResource;
     secretary_details: DirectorOrSecretaryDetailsResource;
     surname: string;
+    liquidators_details: LiquidatorsDetailsResource;
 }
 
 export interface DirectorOrSecretaryDetailsResource {
@@ -86,14 +87,20 @@ export interface OrdinaryMemberDetailsResource extends MemberDetailsResource {
 export interface DesignatedMemberDetailsResource extends MemberDetailsResource {
 }
 
-export interface PartnerDetailsResource {
+export interface BasicInformationResource {
     include_basic_information?: boolean;
+}
+
+export interface PartnerDetailsResource extends BasicInformationResource {
 }
 
 export interface GeneralPartnerDetailsResource extends PartnerDetailsResource {
 }
 
 export interface LimitedPartnerDetailsResource extends PartnerDetailsResource {
+}
+
+export interface LiquidatorsDetailsResource extends BasicInformationResource {
 }
 
 export interface LinksResource {
@@ -151,6 +158,7 @@ export interface ItemOptions {
     registeredOfficeAddressDetails?: RegisteredOfficeAddressDetails;
     secretaryDetails?: DirectorOrSecretaryDetails;
     surname: string;
+    liquidatorsDetails: LiquidatorsDetails;
 }
 
 export interface DirectorOrSecretaryDetails {
@@ -188,14 +196,20 @@ export interface OrdinaryMemberDetails extends MemberDetails {
 export interface DesignatedMemberDetails extends MemberDetails {
 }
 
-export interface PartnerDetails {
+export interface BasicInformation {
     includeBasicInformation?: boolean;
+}
+
+export interface PartnerDetails extends BasicInformation {
 }
 
 export interface GeneralPartnerDetails extends PartnerDetails {
 }
 
 export interface LimitedPartnerDetails extends PartnerDetails {
+}
+
+export interface LiquidatorsDetails extends BasicInformation {
 }
 
 export interface Links {
@@ -239,6 +253,7 @@ export interface ItemOptionsRequest {
     secretaryDetails?: DirectorOrSecretaryDetailsRequest;
     surname?: string;
     companyType?: string;
+    includeLiquidatorsDetails?: LiquidatorsDetailsRequest
 }
 
 export interface DirectorOrSecretaryDetailsRequest {
@@ -276,14 +291,20 @@ export interface OrdinaryMemberDetailsRequest extends MemberDetailsRequest {
 export interface DesignatedMemberDetailsRequest extends MemberDetailsRequest {
 }
 
-export interface PartnerDetailsRequest {
+export interface BasicInformationRequest {
     includeBasicInformation?: boolean | null;
+}
+
+export interface PartnerDetailsRequest extends BasicInformationRequest {
 }
 
 export interface GeneralPartnerDetailsRequest extends PartnerDetailsRequest {
 }
 
 export interface LimitedPartnerDetailsRequest extends PartnerDetailsRequest {
+}
+
+export interface LiquidatorsDetailsRequest extends BasicInformationRequest {
 }
 
 // CertificateItemRequestResource

--- a/src/services/order/certificates/types.ts
+++ b/src/services/order/certificates/types.ts
@@ -253,7 +253,7 @@ export interface ItemOptionsRequest {
     secretaryDetails?: DirectorOrSecretaryDetailsRequest;
     surname?: string;
     companyType?: string;
-    includeLiquidatorsDetails?: LiquidatorsDetailsRequest
+    liquidatorsDetails?: LiquidatorsDetailsRequest
 }
 
 export interface DirectorOrSecretaryDetailsRequest {

--- a/src/services/order/order/mapping.ts
+++ b/src/services/order/order/mapping.ts
@@ -7,7 +7,7 @@ import { MemberDetails } from "../certificates";
 
 export default class OrderMapping {
     public static mapOrderResourceToOrder (orderResource: OrderResource): Order {
-        const order: Order = {
+        return {
             deliveryDetails: {
                 addressLine1: orderResource?.delivery_details?.address_line_1,
                 addressLine2: orderResource?.delivery_details?.address_line_2,
@@ -36,7 +36,6 @@ export default class OrderMapping {
             reference: orderResource.reference,
             totalOrderCost: orderResource.total_order_cost
         }
-        return order;
     }
 
     private static mapItemResourceToItem (itemResource: ItemResource): Item {
@@ -117,6 +116,10 @@ export default class OrderMapping {
                 includeBasicInformation: itemResource?.limited_partner_details?.include_basic_information
             });
 
+            const liquidatorsDetails = this.removeEmptyObjects({
+                includeBasicInformation: itemResource?.liquidators_details?.include_basic_information
+            });
+
             return {
                 certificateType: itemResource.certificate_type,
                 companyType: itemResource.company_type,
@@ -134,7 +137,8 @@ export default class OrderMapping {
                 secretaryDetails: secretaryDetails,
                 directorDetails: directorDetails,
                 forename: itemResource.forename,
-                surname: itemResource.surname
+                surname: itemResource.surname,
+                liquidatorsDetails
             }
         } else if (kind === "item#certified-copy") {
             itemResource = itemResource as CertifiedCopyItemOptionsResource;

--- a/src/services/order/order/types.ts
+++ b/src/services/order/order/types.ts
@@ -115,6 +115,9 @@ export interface CertificateItemOptions {
     };
     forename: string;
     surname: string;
+    liquidatorsDetails: {
+        includeBasicInformation?: boolean;
+    }
 }
 
 export interface CertifiedCopyItemOptions {
@@ -259,6 +262,9 @@ export interface CertificateItemOptionsResource {
     };
     forename: string;
     surname: string;
+    liquidators_details: {
+        include_basic_information?: boolean;
+    }
 }
 
 export interface CertifiedCopyItemOptionsResource {
@@ -287,12 +293,3 @@ export interface MissingImageDeliveryItemOptionsResource {
 export type ItemOptionsResource = CertificateItemOptionsResource | CertifiedCopyItemOptionsResource
    | MissingImageDeliveryItemOptionsResource;
 
-export interface DirectorOrSecretaryDetails {
-    includeBasicInformation?: boolean;
-    includeAddress?: boolean;
-    includeAppointmentDate?: boolean;
-    includeCountryOfResidence?: boolean;
-    includeNationality?: boolean;
-    includeOccupation?: boolean;
-    includeDobType?: string;
-}

--- a/src/services/order/order/types.ts
+++ b/src/services/order/order/types.ts
@@ -292,4 +292,3 @@ export interface MissingImageDeliveryItemOptionsResource {
 
 export type ItemOptionsResource = CertificateItemOptionsResource | CertifiedCopyItemOptionsResource
    | MissingImageDeliveryItemOptionsResource;
-

--- a/test/services/certificates/service.spec.ts
+++ b/test/services/certificates/service.spec.ts
@@ -6,6 +6,7 @@ import chaiHttp from "chai-http";
 import CertificateService from "../../../src/services/order/certificates/service";
 import { RequestClient, HttpResponse } from "../../../src/http";
 import { CertificateItemResource, CertificateItemPostRequest, CertificateItemPatchRequest } from "../../../src/services/order/certificates/types";
+import exp = require("constants");
 const expect = chai.expect;
 
 const requestClient = new RequestClient({ baseUrl: "URL-NOT-USED", oauthToken: "TOKEN-NOT-USED" });
@@ -85,7 +86,10 @@ const mockResponseBody : CertificateItemResource = ({
             include_nationality: true,
             include_occupation: true
         },
-        surname: "surname"
+        surname: "surname",
+        liquidators_details: {
+            include_basic_information: true
+        }
     },
     kind: "kind",
     links: {
@@ -134,7 +138,8 @@ const mockResponseBodyMissingFields : CertificateItemResource = ({
         principal_place_of_business_details: undefined,
         registered_office_address_details: undefined,
         secretary_details: undefined,
-        surname: undefined
+        surname: undefined,
+        liquidators_details: undefined
     },
     kind: "kind",
     links: {
@@ -201,6 +206,7 @@ describe("order a certificate GET", () => {
         const mockMemberDetails = mockItemOptions.member_details;
         const mockLimitedPartnerDetails = mockItemOptions.limited_partner_details;
         const mockGeneralPartnerDetails = mockItemOptions.general_partner_details;
+        const mockLiquidatorsDetails = mockItemOptions.liquidators_details;
 
         expect(data.httpStatusCode).to.equal(200);
         expect(data.resource.companyName).to.equal(mockResponseBody.company_name);
@@ -264,6 +270,7 @@ describe("order a certificate GET", () => {
         expect(data.resource.postalDelivery).to.equal(mockResponseBody.postal_delivery);
         expect(data.resource.quantity).to.equal(mockResponseBody.quantity);
         expect(data.resource.totalItemCost).to.equal(mockResponseBody.total_item_cost);
+        expect(resourceItemOptions.liquidatorsDetails.includeBasicInformation).to.equal(mockLiquidatorsDetails.include_basic_information);
     });
 
     it("maps the certificate field data items correctly when director, secretary and office address details and surname are missing", async () => {
@@ -341,6 +348,7 @@ describe("order a certificate GET", () => {
         expect(data.resource.postalDelivery).to.equal(mockResponseBodyMissingFields.postal_delivery);
         expect(data.resource.quantity).to.equal(mockResponseBodyMissingFields.quantity);
         expect(data.resource.totalItemCost).to.equal(mockResponseBodyMissingFields.total_item_cost);
+        expect(resourceItemOptions.liquidatorsDetails?.includeBasicInformation).to.be.undefined;
     });
 });
 
@@ -405,7 +413,10 @@ describe("create a certificate POST", () => {
                 includeNationality: true,
                 includeOccupation: true
             },
-            surname: "surname"
+            surname: "surname",
+            includeLiquidatorsDetails: {
+                includeBasicInformation: true
+            }
         },
         quantity: 1
     });
@@ -493,6 +504,7 @@ describe("create a certificate POST", () => {
         expect(io.secretaryDetails.includeOccupation).to.equal(mockIo.secretary_details.include_occupation);
         expect(io.surname).to.equal(mockIo.surname);
         expect(data.resource.quantity).to.equal(mockResponseBody.quantity);
+        expect(io.liquidatorsDetails.includeBasicInformation).to.equal(mockIo.liquidators_details.include_basic_information);
     });
 
     it("maps create a certificate correctly when director, secretary, registered office address details and surname are missing", async () => {
@@ -525,6 +537,7 @@ describe("create a certificate POST", () => {
         expect(io.secretaryDetails).to.be.undefined;
         expect(io.surname).to.be.undefined;
         expect(data.resource.quantity).to.equal(mockResponseBodyMissingFields.quantity);
+        expect(io.liquidatorsDetails).to.be.undefined;
     });
 });
 
@@ -590,7 +603,10 @@ describe("update a certificate PATCH", () => {
                 includeNationality: true,
                 includeOccupation: true
             },
-            surname: "surname"
+            surname: "surname",
+            includeLiquidatorsDetails: {
+                includeBasicInformation: true
+            }
         },
         quantity: 1
     });
@@ -678,6 +694,7 @@ describe("update a certificate PATCH", () => {
         expect(io.secretaryDetails.includeOccupation).to.equal(mockIo.secretary_details.include_occupation);
         expect(io.surname).to.equal(mockIo.surname);
         expect(data.resource.quantity).to.equal(mockResponseBody.quantity);
+        expect(io.liquidatorsDetails.includeBasicInformation).to.equal(mockIo.liquidators_details.include_basic_information);
     });
 
     it("maps patch a certificate correctly when director, secretary, registered office address details and surname are missing", async () => {
@@ -710,5 +727,6 @@ describe("update a certificate PATCH", () => {
         expect(io.secretaryDetails).to.be.undefined;
         expect(io.surname).to.be.undefined;
         expect(data.resource.quantity).to.equal(mockResponseBodyMissingFields.quantity);
+        expect(io.liquidatorsDetails).to.be.undefined;
     });
 });

--- a/test/services/certificates/service.spec.ts
+++ b/test/services/certificates/service.spec.ts
@@ -6,7 +6,6 @@ import chaiHttp from "chai-http";
 import CertificateService from "../../../src/services/order/certificates/service";
 import { RequestClient, HttpResponse } from "../../../src/http";
 import { CertificateItemResource, CertificateItemPostRequest, CertificateItemPatchRequest } from "../../../src/services/order/certificates/types";
-import exp = require("constants");
 const expect = chai.expect;
 
 const requestClient = new RequestClient({ baseUrl: "URL-NOT-USED", oauthToken: "TOKEN-NOT-USED" });

--- a/test/services/certificates/service.spec.ts
+++ b/test/services/certificates/service.spec.ts
@@ -414,7 +414,7 @@ describe("create a certificate POST", () => {
                 includeOccupation: true
             },
             surname: "surname",
-            includeLiquidatorsDetails: {
+            liquidatorsDetails: {
                 includeBasicInformation: true
             }
         },
@@ -604,7 +604,7 @@ describe("update a certificate PATCH", () => {
                 includeOccupation: true
             },
             surname: "surname",
-            includeLiquidatorsDetails: {
+            liquidatorsDetails: {
                 includeBasicInformation: true
             }
         },

--- a/test/services/order/service.spec.ts
+++ b/test/services/order/service.spec.ts
@@ -389,7 +389,7 @@ describe("order", () => {
             expect(itemOptions.surname).to.equal(itemOptionsResource.surname);
             expect(itemOptions.designatedMemberDetails).to.deep.equal({ includeAddress: true, includeAppointmentDate: false, includeBasicInformation: true, includeCountryOfResidence: false, includeDobType: "partial" })
             expect(itemOptions.memberDetails).to.deep.equal({ includeAddress: false, includeAppointmentDate: false, includeBasicInformation: true, includeCountryOfResidence: false, includeDobType: "partial" })
-            expect(itemOptions.liquidatorsDetails).to.deep.equal({ includeBasicInformation: false } );
+            expect(itemOptions.liquidatorsDetails).to.deep.equal({ includeBasicInformation: false });
         });
 
         it("should map certified copy item option fields correctly", async () => {

--- a/test/services/order/service.spec.ts
+++ b/test/services/order/service.spec.ts
@@ -84,7 +84,10 @@ const mockCertificateOrderResponseBody: OrderResource = {
             principal_place_of_business_details: {},
             registered_office_address_details: {},
             secretary_details: {},
-            surname: "surname"
+            surname: "surname",
+            liquidators_details: {
+                include_basic_information: false
+            }
         },
         etag: "abcdefg123456",
         kind: "item#certificate",
@@ -386,6 +389,7 @@ describe("order", () => {
             expect(itemOptions.surname).to.equal(itemOptionsResource.surname);
             expect(itemOptions.designatedMemberDetails).to.deep.equal({ includeAddress: true, includeAppointmentDate: false, includeBasicInformation: true, includeCountryOfResidence: false, includeDobType: "partial" })
             expect(itemOptions.memberDetails).to.deep.equal({ includeAddress: false, includeAppointmentDate: false, includeBasicInformation: true, includeCountryOfResidence: false, includeDobType: "partial" })
+            expect(itemOptions.liquidatorsDetails).to.deep.equal({ includeBasicInformation: false } );
         });
 
         it("should map certified copy item option fields correctly", async () => {


### PR DESCRIPTION
- Add liquidators details types and mappings
- Fix Typescript warnings
- Remove unused imports and types

Resolves: [Add liquidators_details field: api-sdk-node](https://companieshouse.atlassian.net/browse/BI-9543) 