### PR TITLE
Add liquidators details fields

### DIFF
--- a/src/services/order/checkout/mapping.ts
+++ b/src/services/order/checkout/mapping.ts
@@ -119,6 +119,10 @@ export default class CheckoutMapping {
                 includeBasicInformation: itemResource?.limited_partner_details?.include_basic_information
             });
 
+            const liquidatorsDetails = this.removeEmptyObjects({
+                includeBasicInformation: itemResource?.liquidators_details?.include_basic_information
+            });
+
             return {
                 certificateType: itemResource.certificate_type,
                 companyType: itemResource.company_type,
@@ -136,7 +140,8 @@ export default class CheckoutMapping {
                 secretaryDetails: secretaryDetails,
                 directorDetails: directorDetails,
                 forename: itemResource.forename,
-                surname: itemResource.surname
+                surname: itemResource.surname,
+                liquidatorsDetails: liquidatorsDetails
             }
         } else if (kind === "item#certified-copy") {
             itemResource = itemResource as CertifiedCopyItemOptionsResource;

--- a/src/services/order/checkout/types.ts
+++ b/src/services/order/checkout/types.ts
@@ -117,6 +117,9 @@ export interface CertificateItemOptions {
     };
     forename: string;
     surname: string;
+    liquidatorsDetails: {
+        includeBasicInformation?: boolean;
+    }
 }
 
 export interface CertifiedCopyItemOptions {
@@ -263,6 +266,9 @@ export interface CertificateItemOptionsResource {
     };
     forename: string;
     surname: string;
+    liquidators_details: {
+        include_basic_information?: boolean;
+    }
 }
 
 export interface CertifiedCopyItemOptionsResource {

--- a/src/services/order/order/mapping.ts
+++ b/src/services/order/order/mapping.ts
@@ -138,7 +138,7 @@ export default class OrderMapping {
                 directorDetails: directorDetails,
                 forename: itemResource.forename,
                 surname: itemResource.surname,
-                liquidatorsDetails
+                liquidatorsDetails: liquidatorsDetails
             }
         } else if (kind === "item#certified-copy") {
             itemResource = itemResource as CertifiedCopyItemOptionsResource;

--- a/src/services/order/order/types.ts
+++ b/src/services/order/order/types.ts
@@ -292,3 +292,13 @@ export interface MissingImageDeliveryItemOptionsResource {
 
 export type ItemOptionsResource = CertificateItemOptionsResource | CertifiedCopyItemOptionsResource
    | MissingImageDeliveryItemOptionsResource;
+
+export interface DirectorOrSecretaryDetails {
+    includeBasicInformation?: boolean;
+    includeAddress?: boolean;
+    includeAppointmentDate?: boolean;
+    includeCountryOfResidence?: boolean;
+    includeNationality?: boolean;
+    includeOccupation?: boolean;
+    includeDobType?: string;
+}

--- a/test/services/checkout/service.spec.ts
+++ b/test/services/checkout/service.spec.ts
@@ -86,7 +86,8 @@ const mockCertificateCheckoutResponseBody: CheckoutResource = {
             principal_place_of_business_details: {},
             registered_office_address_details: {},
             secretary_details: {},
-            surname: "surname"
+            surname: "surname",
+            liquidators_details: {}
         },
         etag: "abcdefg123456",
         kind: "item#certificate",


### PR DESCRIPTION
* Add missed liquidators details fields to checkout types and mapping
* Add missed liquidators details fields to order types and mapping
* Re-instate removed DirectorOrSecretaryDetails interface (required by orders.web.ch.gov.uk)

Resolves: [Upgrade api-sdk-node version: orders.web.ch.gov.uk](https://companieshouse.atlassian.net/browse/BI-9545)