### PR TITLE
BI-9889 Unify create and certificate initial and post response

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ clean:
 .PHONY: build
 build:
 	npm i
+	npm run lint
 	npm run build
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ clean:
 .PHONY: build
 build:
 	npm i
-	npm run lint
 	npm run build
 
 .PHONY: lint

--- a/src/services/order/certificates/service.ts
+++ b/src/services/order/certificates/service.ts
@@ -28,7 +28,7 @@ export default class {
     }
 
     // Create a whole certificate item in one invocation
-    public async postCertificate (certificateItemRequest: CertificateItemPostRequest): Promise<Resource<CertificateItem>> {
+    public async postCertificate (certificateItemRequest: CertificateItemPostRequest): Promise<ApiResult<ApiResponse<CertificateItem>>> {
         return this.postCertificateRequest(certificateItemRequest, "/orderable/certificates");
     }
 
@@ -38,22 +38,7 @@ export default class {
      * Note: use patchCertificate to add or amend certificate item properties.
      */
     public async postInitialCertificate (certificateItemRequest: CertificateItemInitialRequest): Promise<ApiResult<ApiResponse<CertificateItem>>> {
-        const postRequest = Mapping.snakeCaseKeys(certificateItemRequest);
-
-        const serverResponse = await this.client.httpPost("/orderable/certificates/initial", postRequest);
-        const response: ApiResponse<CertificateItem> = {
-            httpStatusCode: serverResponse.status
-        };
-
-        if (serverResponse.error) {
-            return failure({
-                httpStatusCode: serverResponse.status,
-                errors: serverResponse.error.errors
-            });
-        } else {
-            response.resource = Mapping.camelCaseKeys<CertificateItem>(serverResponse.body);
-            return success(response);
-        }
+        return this.postCertificateRequest(certificateItemRequest, "/orderable/certificates/initial");
     }
 
     /*
@@ -81,19 +66,22 @@ export default class {
         return resource;
     }
 
-    private async postCertificateRequest (certificateItemRequest: CertificateItemInitialRequest | CertificateItemPostRequest, url: string): Promise<Resource<CertificateItem>> {
+    private async postCertificateRequest (certificateItemRequest: CertificateItemInitialRequest | CertificateItemPostRequest, url: string): Promise<ApiResult<ApiResponse<CertificateItem>>> {
         const postRequest = Mapping.snakeCaseKeys(certificateItemRequest);
 
-        const resp = await this.client.httpPost(url, postRequest);
-
-        const resource: Resource<CertificateItem> = {
-            httpStatusCode: resp.status
+        const serverResponse = await this.client.httpPost(url, postRequest);
+        const response: ApiResponse<CertificateItem> = {
+            httpStatusCode: serverResponse.status
         };
 
-        if (!resp.error) {
-            resource.resource = Mapping.camelCaseKeys(resp.body);
+        if (serverResponse.error) {
+            return failure({
+                httpStatusCode: serverResponse.status,
+                errors: serverResponse.error.errors
+            });
+        } else {
+            response.resource = Mapping.camelCaseKeys<CertificateItem>(serverResponse.body);
+            return success(response);
         }
-
-        return resource;
     }
 }

--- a/test/services/certificates/service.spec.ts
+++ b/test/services/certificates/service.spec.ts
@@ -10,8 +10,8 @@ import {
     CertificateItemPostRequest,
     CertificateItemResource
 } from "../../../src/services/order/certificates/types";
-import Resource, {ApiErrorResponse, ApiResponse, ApiResult} from "../../../src/services/resource";
-import {Failure, Success} from "../../../src/services/result";
+import { ApiErrorResponse, ApiResponse } from "../../../src/services/resource";
+import { Failure, Success } from "../../../src/services/result";
 
 const expect = chai.expect;
 
@@ -449,7 +449,7 @@ describe("create a certificate POST", () => {
         const mockPostRequest = {
             status: 401,
             error: {
-                errors: [{error: "An error occurred"}]
+                errors: [{ error: "An error occurred" }]
             }
         };
 


### PR DESCRIPTION
* Standardise on ApiResponse as the response object from both initial and create
  requests

Relates to: [Refactor company status and info into an enrichment](https://companieshouse.atlassian.net/browse/BI-9889)