### PR TITLE
add company subtype to advanced search query params update test

### DIFF
--- a/src/services/search/advanced-search/service.ts
+++ b/src/services/search/advanced-search/service.ts
@@ -6,7 +6,7 @@ import "url-search-params-polyfill";
 export default class AdvancedSearchService {
     constructor (private readonly client: IHttpClient) { }
     public async getCompanies (startIndex: number | null, companyNameIncludes: string | null, companyNameExcludes: string | null, location: string | null, incorporatedFrom: string | null,
-        incorporatedTo: string | null, sicCodes: string | null, companyStatus: string | null, companyType: string | null, dissolvedFrom: string | null,
+        incorporatedTo: string | null, sicCodes: string | null, companyStatus: string | null, companyType: string | null, companySubtype: string | null, dissolvedFrom: string | null,
         dissolvedTo: string | null, size: number | null, requestId: string): Promise<Resource<CompaniesResource>> {
         const START_INDEX_QUERY = "start_index";
         const COMPANY_NAME_INCLUDES_QUERY = "company_name_includes";
@@ -17,6 +17,7 @@ export default class AdvancedSearchService {
         const SIC_CODES_QUERY = "sic_codes";
         const COMPANY_STATUS_QUERY = "company_status";
         const COMPANY_TYPE_QUERY = "company_type";
+        const COMPANY_SUBTYPE_QUERY = "company_subtype";
         const DISSOLVED_FROM_QUERY_PARAMETER = "dissolved_from";
         const DISSOLVED_TO_QUERY_PARAMETER = "dissolved_to";
         const SIZE_QUERY_PARAMETER = "size";
@@ -61,6 +62,10 @@ export default class AdvancedSearchService {
 
         if (companyType !== null) {
             buildAdvancedSearchURL.append(COMPANY_TYPE_QUERY, companyType)
+        }
+
+        if (companySubtype !== null) {
+            buildAdvancedSearchURL.append(COMPANY_SUBTYPE_QUERY, companySubtype)
         }
 
         if (dissolvedFrom !== null) {

--- a/src/services/search/advanced-search/types.ts
+++ b/src/services/search/advanced-search/types.ts
@@ -11,6 +11,7 @@ export interface Items {
     company_number: string;
     company_status: string;
     company_type: string;
+    company_subtype: string;
     kind: string;
     links: Links;
     date_of_cessation: Date;
@@ -34,6 +35,7 @@ export interface TopHit {
     company_number: string;
     company_status: string;
     company_type: string;
+    company_subtype: string;
     kind: string;
     links: Links;
     date_of_cessation: Date;

--- a/test/services/search/advanced-search/service.spec.ts
+++ b/test/services/search/advanced-search/service.spec.ts
@@ -17,6 +17,7 @@ const mockResponseBody : CompaniesResource = ({
         company_number: "0000789",
         company_status: "active",
         company_type: "company type",
+        company_subtype: "company subtype",
         kind: "kind",
         links: {
             company_profile: "/company/FC022000"
@@ -42,6 +43,7 @@ const mockResponseBody : CompaniesResource = ({
             company_number: "0000789",
             company_status: "active",
             company_type: "company type",
+            company_subtype: "company subtype",
             kind: "kind",
             links: {
                 company_profile: "/company/FC022000"
@@ -76,6 +78,7 @@ const testIncorporatedTo = "TEST INCORPORATED TO";
 const testSicCodes = "999999";
 const testCompanyStatus = "TEST COMPANY STATUS";
 const testCompanyType = "TEST COMPANY TYPE";
+const testCompanySubtype = "TEST COMPANY SUBTYPE"
 const testDissolvedFrom = "TEST DISSOLVED FROM";
 const testDissolvedTo = "TEST DISSOLVED TO";
 const searchType = "advanced";
@@ -102,7 +105,7 @@ describe("create an advanced search GET", () => {
         const mockRequest = sinon.stub(requestClient, "httpGet").resolves(mockGetRequest);
         const search: AdvancedSearchService = new AdvancedSearchService(requestClient);
         const data: Resource<CompaniesResource> = await search.getCompanies(testStartIndex, testCompanyNameIncludes, testCompanyNameExcludes, testLocation, testIncorporatedFrom,
-            testIncorporatedTo, testSicCodes, testCompanyStatus, testCompanyType, testDissolvedFrom, testDissolvedTo, size, mockRequestId);
+            testIncorporatedTo, testSicCodes, testCompanyStatus, testCompanyType, testCompanySubtype, testDissolvedFrom, testDissolvedTo, size, mockRequestId);
 
         expect(data.httpStatusCode).to.equal(401);
         expect(data.resource).to.be.undefined;
@@ -117,7 +120,7 @@ describe("create an advanced search GET", () => {
         const mockRequest = sinon.stub(requestClient, "httpGet").resolves(mockGetRequest);
         const search: AdvancedSearchService = new AdvancedSearchService(requestClient);
         const data: Resource<CompaniesResource> = await search.getCompanies(testStartIndex, testCompanyNameIncludes, testCompanyNameExcludes, testLocation, testIncorporatedFrom,
-            testIncorporatedTo, testSicCodes, testCompanyStatus, testCompanyNameIncludes, testDissolvedFrom, testDissolvedTo, size, mockRequestId);
+            testIncorporatedTo, testSicCodes, testCompanyStatus, testCompanyType, testCompanySubtype, testDissolvedFrom, testDissolvedTo, size, mockRequestId);
         const item = data.resource.items[0];
         const mockItem = mockResponseBody.items[0];
 
@@ -127,6 +130,7 @@ describe("create an advanced search GET", () => {
         expect(data.resource.top_hit.company_number).to.equal(mockResponseBody.top_hit.company_number);
         expect(data.resource.top_hit.company_status).to.equal(mockResponseBody.top_hit.company_status);
         expect(data.resource.top_hit.company_type).to.equal(mockResponseBody.top_hit.company_type);
+        expect(data.resource.top_hit.company_subtype).to.equal(mockResponseBody.top_hit.company_subtype);
         expect(data.resource.top_hit.kind).to.equal(mockResponseBody.top_hit.kind);
         expect(data.resource.top_hit.links.company_profile).to.equal(mockResponseBody.top_hit.links.company_profile);
         expect(data.resource.top_hit.date_of_cessation).to.equal(mockResponseBody.top_hit.date_of_cessation);
@@ -142,6 +146,7 @@ describe("create an advanced search GET", () => {
         expect(item.company_number).to.equal(mockItem.company_number);
         expect(item.company_status).to.equal(mockItem.company_status);
         expect(item.company_type).to.equal(mockItem.company_type);
+        expect(item.company_subtype).to.equal(mockItem.company_subtype);
         expect(item.kind).to.equal(mockItem.kind);
         expect(item.links.company_profile).to.equal(mockItem.links.company_profile);
         expect(item.date_of_cessation).to.equal(mockItem.date_of_cessation);


### PR DESCRIPTION
Allow search api to be called from the web with a company_subtype query param values via sdk

Resolves: BI-10797