### PR TITLE
GCI-2073 Support page_size param in orders search endpoint

### DIFF
--- a/src/services/order/search/types.ts
+++ b/src/services/order/search/types.ts
@@ -2,6 +2,7 @@ export interface SearchRequest {
     id?: string;
     email?: string;
     companyNumber?: string;
+    pageSize: number;
 }
 
 export interface SearchResponse {


### PR DESCRIPTION
* The page_size query parameter controls how many results will be
  returned per page by the orders search endpoint.