### PR TITLE
ROE-849 Send nulls for empty due diligence objects

### DIFF
--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -128,6 +128,8 @@ const mapDueDiligence = (dueDiligence: DueDiligence): DueDiligenceResource => {
             identity_date
         }
     }
+
+    // This object is optionally present - API will ignore it if sent as null but not as {}
     return null;
 }
 
@@ -145,6 +147,8 @@ const mapOverseasEntityDueDiligence = (oeDueDiligence: OverseasEntityDueDiligenc
             ? { ...rest, identity_date: identityDateResource }
             : { ...rest };
     }
+
+    // This object is optionally present - API will ignore it if sent as null but not as {}
     return null;
 }
 

--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -128,7 +128,7 @@ const mapDueDiligence = (dueDiligence: DueDiligence): DueDiligenceResource => {
             identity_date
         }
     }
-    return {};
+    return null;
 }
 
 /**
@@ -145,7 +145,7 @@ const mapOverseasEntityDueDiligence = (oeDueDiligence: OverseasEntityDueDiligenc
             ? { ...rest, identity_date: identityDateResource }
             : { ...rest };
     }
-    return {};
+    return null;
 }
 
 /**

--- a/test/services/overseas-entities/overseas.entities.spec.ts
+++ b/test/services/overseas-entities/overseas.entities.spec.ts
@@ -94,8 +94,8 @@ describe("Mapping OverseasEntity Tests suite", () => {
 
         expect(data.presenter).to.deep.equal({});
         expect(data.entity).to.deep.equal({});
-        expect(data.due_diligence).to.deep.equal({});
-        expect(data.overseas_entity_due_diligence).to.deep.equal({});
+        expect(data.due_diligence).to.deep.equal(null);
+        expect(data.overseas_entity_due_diligence).to.deep.equal(null);
         expect(data.beneficial_owners_statement).to.deep.equal(undefined);
         expect(data.beneficial_owners_individual).to.deep.equal([]);
         expect(data.beneficial_owners_corporate).to.deep.equal([]);


### PR DESCRIPTION
* Send null instead of {} if due didligence object is empty
* Ensures object field not written by API to Mongo and fixes
  an issue in chips-filing-consumer