### PR TITLE
Add condition to catch when items array undefined

### DIFF
--- a/src/services/order/checkout-item/service.ts
+++ b/src/services/order/checkout-item/service.ts
@@ -32,7 +32,7 @@ export default class CheckoutItemService {
 
         const body = resp.body as CheckoutResource;
 
-        if (body.items.length !== 1) {
+        if (!body.items || body.items.length !== 1) {
             return failure({
                 httpStatusCode: resp.status,
                 error: "Expected checkout returned by api to have exactly one embedded item."

--- a/test/services/checkout-item/service.spec.ts
+++ b/test/services/checkout-item/service.spec.ts
@@ -222,8 +222,28 @@ describe("CheckoutItemService", () => {
             expect(actual.value.error).to.equal("An error occurred");
         });
 
-        // Returns failure with response code attached if items does not contain exactly one item
-        it("test me please", async () => {
+        it("Returns failure with response code attached if items is undefined", async () => {
+            // given
+            const serverResponse = {
+                status: 200,
+                body: {}
+            };
+            sandbox.mock(requestClient)
+                .expects("httpGet")
+                .once()
+                .withArgs("/checkouts/ORD-123123-123123/items/CCD-123456-123456")
+                .returns(serverResponse);
+            const checkoutItemService = new CheckoutItemService(requestClient);
+
+            // when
+            const actual = await checkoutItemService.getCheckoutItem("ORD-123123-123123", "CCD-123456-123456") as Failure<Checkout, CheckoutItemErrorResponse>;
+
+            expect(actual.isFailure()).to.be.true;
+            expect(actual.value.httpStatusCode).to.equal(200);
+            expect(actual.value.error).to.equal("Expected checkout returned by api to have exactly one embedded item.");
+        });
+
+        it("Returns failure with response code attached if items does not contain exactly one item", async () => {
             // given
             const serverResponse = {
                 status: 200,


### PR DESCRIPTION
* Adds condition which checks for items to exists on the response body before checking its length

