### PR TITLE
Return null object when presenter and entity are empty

### DIFF
--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -26,8 +26,8 @@ import {
 
 export const mapOverseasEntity = (body: OverseasEntity): OverseasEntityResource => {
     return {
-        presenter: { ...body.presenter },
-        entity: { ...body.entity },
+        presenter: (body.presenter && Object.keys(body.presenter).length) ? { ...body.presenter } : null,
+        entity: (body.entity && Object.keys(body.entity).length) ? { ...body.entity } : null,
         due_diligence: mapDueDiligence(body.due_diligence),
         overseas_entity_due_diligence: mapOverseasEntityDueDiligence(body.overseas_entity_due_diligence),
         beneficial_owners_statement: body.beneficial_owners_statement,

--- a/test/services/overseas-entities/overseas.entities.spec.ts
+++ b/test/services/overseas-entities/overseas.entities.spec.ts
@@ -134,8 +134,8 @@ describe("Mapping OverseasEntity Tests suite", () => {
             trusts: []
         });
 
-        expect(data.presenter).to.deep.equal({});
-        expect(data.entity).to.deep.equal({});
+        expect(data.presenter).to.deep.equal(null);
+        expect(data.entity).to.deep.equal(null);
         expect(data.due_diligence).to.deep.equal(null);
         expect(data.overseas_entity_due_diligence).to.deep.equal(null);
         expect(data.beneficial_owners_statement).to.deep.equal(undefined);


### PR DESCRIPTION
Part of [ROE-1677](https://companieshouse.atlassian.net/browse/ROE-1677)

Return null object for the `presenter` and `entity` when they are empty