### PR TITLE
Roe 1750 add entity name model

### DIFF
--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -26,7 +26,7 @@ import {
 
 export const mapOverseasEntity = (body: OverseasEntity): OverseasEntityResource => {
     return {
-        entity_name: (body.entity_name && Object.keys(body.entity_name).length) ? { ...body.entity_name } : null,
+        entity_name: (body.entity_name) ? body.entity_name : null,
         presenter: (body.presenter && Object.keys(body.presenter).length) ? { ...body.presenter } : null,
         entity: (body.entity && Object.keys(body.entity).length) ? { ...body.entity } : null,
         due_diligence: mapDueDiligence(body.due_diligence),
@@ -43,7 +43,7 @@ export const mapOverseasEntity = (body: OverseasEntity): OverseasEntityResource 
 
 export const mapOverseasEntityResource = (body: OverseasEntityResource): OverseasEntity => {
     return {
-        entity_name: { ...body.entity_name },
+        entity_name: body.entity_name,
         presenter: { ...body.presenter },
         entity: { ...body.entity },
         due_diligence: (body.due_diligence && Object.keys(body.due_diligence).length) ? {

--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -26,6 +26,7 @@ import {
 
 export const mapOverseasEntity = (body: OverseasEntity): OverseasEntityResource => {
     return {
+        entity_name: (body.entity_name && Object.keys(body.entity_name).length) ? { ...body.entity_name } : null,
         presenter: (body.presenter && Object.keys(body.presenter).length) ? { ...body.presenter } : null,
         entity: (body.entity && Object.keys(body.entity).length) ? { ...body.entity } : null,
         due_diligence: mapDueDiligence(body.due_diligence),
@@ -42,6 +43,7 @@ export const mapOverseasEntity = (body: OverseasEntity): OverseasEntityResource 
 
 export const mapOverseasEntityResource = (body: OverseasEntityResource): OverseasEntity => {
     return {
+        entity_name: { ...body.entity_name },
         presenter: { ...body.presenter },
         entity: { ...body.entity },
         due_diligence: (body.due_diligence && Object.keys(body.due_diligence).length) ? {

--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -3,6 +3,7 @@
  */
 
 export interface OverseasEntity {
+    entity_name?: EntityName;
     presenter?: Presenter;
     entity?: Entity;
     due_diligence?: DueDiligence;
@@ -17,6 +18,7 @@ export interface OverseasEntity {
 }
 
 export interface OverseasEntityResource {
+    entity_name?: EntityName;
     presenter?: Presenter;
     entity?: Entity;
     due_diligence?: DueDiligenceResource;
@@ -40,6 +42,10 @@ export interface HttpStatusCode {
 /**
  * Overseas Entities interface used on OverseasEntity object
  */
+export interface EntityName {
+    name?: string
+}
+
 export interface Presenter {
     full_name?: string
     email?: string

--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -52,7 +52,6 @@ export interface Presenter {
 }
 
 export interface Entity {
-    name?: string
     incorporation_country?: string
     principal_address?: Address
     is_service_address_same_as_principal_address?: yesNoResponse

--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -3,7 +3,7 @@
  */
 
 export interface OverseasEntity {
-    entity_name?: EntityName;
+    entity_name?: string;
     presenter?: Presenter;
     entity?: Entity;
     due_diligence?: DueDiligence;
@@ -18,7 +18,7 @@ export interface OverseasEntity {
 }
 
 export interface OverseasEntityResource {
-    entity_name?: EntityName;
+    entity_name?: string;
     presenter?: Presenter;
     entity?: Entity;
     due_diligence?: DueDiligenceResource;
@@ -42,9 +42,6 @@ export interface HttpStatusCode {
 /**
  * Overseas Entities interface used on OverseasEntity object
  */
-export interface EntityName {
-    name?: string
-}
 
 export interface Presenter {
     full_name?: string

--- a/test/services/overseas-entities/overseas.entities.mock.ts
+++ b/test/services/overseas-entities/overseas.entities.mock.ts
@@ -11,7 +11,6 @@ import {
     DueDiligence,
     DueDiligenceResource,
     Entity,
-    EntityName,
     ManagingOfficerCorporate,
     ManagingOfficerCorporateResource,
     ManagingOfficerIndividual,
@@ -44,9 +43,7 @@ export const ADDRESS: Address = {
     postcode: "BY 2"
 };
 
-export const ENTITY_NAME_MOCK: EntityName = {
-    name: "Entity Name"
-};
+export const ENTITY_NAME_MOCK = "Entity Name";
 
 export const PRESENTER_OBJECT_MOCK: Presenter = {
     full_name: "Full Name",

--- a/test/services/overseas-entities/overseas.entities.mock.ts
+++ b/test/services/overseas-entities/overseas.entities.mock.ts
@@ -54,7 +54,6 @@ export const PRESENTER_OBJECT_MOCK: Presenter = {
 };
 
 export const ENTITY_OBJECT_MOCK: Entity = {
-    name: "overseasEntityName",
     incorporation_country: "incorporationCountry",
     principal_address: ADDRESS,
     is_service_address_same_as_principal_address: 0,

--- a/test/services/overseas-entities/overseas.entities.mock.ts
+++ b/test/services/overseas-entities/overseas.entities.mock.ts
@@ -8,8 +8,10 @@ import {
     BeneficialOwnerIndividual,
     BeneficialOwnerIndividualResource,
     BeneficialOwnersStatementType,
-    DueDiligence, DueDiligenceResource,
+    DueDiligence,
+    DueDiligenceResource,
     Entity,
+    EntityName,
     ManagingOfficerCorporate,
     ManagingOfficerCorporateResource,
     ManagingOfficerIndividual,
@@ -40,6 +42,10 @@ export const ADDRESS: Address = {
     county: "county",
     country: "country",
     postcode: "BY 2"
+};
+
+export const ENTITY_NAME_MOCK: EntityName = {
+    name: "Entity Name"
 };
 
 export const PRESENTER_OBJECT_MOCK: Presenter = {
@@ -329,6 +335,7 @@ export const TRUSTS_MOCK: Trust[] = [{
 }]
 
 export const OVERSEAS_ENTITY_OBJECT_MOCK: OverseasEntity = {
+    entity_name: ENTITY_NAME_MOCK,
     presenter: PRESENTER_OBJECT_MOCK,
     entity: ENTITY_OBJECT_MOCK,
     due_diligence: DUE_DILIGENCE_MOCK,
@@ -418,6 +425,7 @@ export const TRUSTS_RESOURCE_MOCK: TrustResource[] = [{
 }]
 
 export const OVERSEAS_ENTITY_RESOURCE_OBJECT_MOCK: OverseasEntityResource = {
+    entity_name: ENTITY_NAME_MOCK,
     presenter: PRESENTER_OBJECT_MOCK,
     entity: ENTITY_OBJECT_MOCK,
     due_diligence: DUE_DILIGENCE_RESOURCE_MOCK,

--- a/test/services/overseas-entities/overseas.entities.spec.ts
+++ b/test/services/overseas-entities/overseas.entities.spec.ts
@@ -169,7 +169,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
             managing_officers_corporate: [],
             trusts: []
         });
-
+        expect(data.entity_name).to.deep.equal(null);
         expect(data.presenter).to.deep.equal(null);
         expect(data.entity).to.deep.equal(null);
         expect(data.due_diligence).to.deep.equal(null);
@@ -260,7 +260,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
             trusts: undefined
         });
 
-        expect(data.entity_name).to.deep.equal({});
+        expect(data.entity_name).to.deep.equal(undefined);
         expect(data.presenter).to.deep.equal(mockValues.PRESENTER_OBJECT_MOCK);
         expect(data.entity).to.deep.equal({});
         expect(data.due_diligence).to.deep.equal({});

--- a/test/services/overseas-entities/overseas.entities.spec.ts
+++ b/test/services/overseas-entities/overseas.entities.spec.ts
@@ -244,7 +244,6 @@ describe("Mapping OverseasEntity Tests suite", () => {
         expect(data.trusts).to.deep.equal([]);
     });
 
-
     it("should return OverseasEntity object from mapOverseasEntityResource method with just Presenter data", async () => {
         const data = mapOverseasEntityResource({
             entity_name: undefined,

--- a/test/services/overseas-entities/overseas.entities.spec.ts
+++ b/test/services/overseas-entities/overseas.entities.spec.ts
@@ -125,6 +125,7 @@ describe("OverseasEntityService GET Tests suite", () => {
 describe("Mapping OverseasEntity Tests suite", () => {
     it("should return OverseasEntityResource object from mapOverseasEntity method", async () => {
         const data = mapOverseasEntity({
+            entity_name: mockValues.ENTITY_NAME_MOCK,
             presenter: mockValues.PRESENTER_OBJECT_MOCK,
             entity: mockValues.ENTITY_OBJECT_MOCK,
             due_diligence: mockValues.DUE_DILIGENCE_MOCK,
@@ -138,6 +139,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
             trusts: mockValues.TRUSTS_MOCK
         });
 
+        expect(data.entity_name).to.deep.equal(mockValues.OVERSEAS_ENTITY_RESOURCE_OBJECT_MOCK.entity_name);
         expect(data.presenter).to.deep.equal(mockValues.OVERSEAS_ENTITY_RESOURCE_OBJECT_MOCK.presenter);
         expect(data.entity).to.deep.equal(mockValues.OVERSEAS_ENTITY_RESOURCE_OBJECT_MOCK.entity);
         expect(data.due_diligence).to.deep.equal(mockValues.OVERSEAS_ENTITY_RESOURCE_OBJECT_MOCK.due_diligence);
@@ -154,6 +156,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
 
     it("should return OverseasEntityResource object from mapOverseasEntity method with all empty sub fields", async () => {
         const data = mapOverseasEntity({
+            entity_name: undefined,
             presenter: undefined,
             entity: undefined,
             due_diligence: undefined,
@@ -183,6 +186,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
     it("should return OverseasEntity object from mapOverseasEntityResource method", async () => {
         const OE_RESOURCE = mockValues.OVERSEAS_ENTITY_RESOURCE_OBJECT_MOCK;
         const data = mapOverseasEntityResource({
+            entity_name: OE_RESOURCE.entity_name,
             presenter: OE_RESOURCE.presenter,
             entity: OE_RESOURCE.entity,
             due_diligence: OE_RESOURCE.due_diligence,
@@ -196,6 +200,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
             trusts: OE_RESOURCE.trusts
         });
 
+        expect(data.entity_name).to.deep.equal(mockValues.ENTITY_NAME_MOCK);
         expect(data.presenter).to.deep.equal(mockValues.PRESENTER_OBJECT_MOCK);
         expect(data.entity).to.deep.equal(mockValues.ENTITY_OBJECT_MOCK);
         expect(data.due_diligence).to.deep.equal(mockValues.DUE_DILIGENCE_MOCK);
@@ -209,8 +214,40 @@ describe("Mapping OverseasEntity Tests suite", () => {
         expect(data.trusts).to.deep.equal(mockValues.TRUSTS_MOCK);
     });
 
+    it("should return OverseasEntity object from mapOverseasEntityResource method with just EntityName data", async () => {
+        const data = mapOverseasEntityResource({
+            entity_name: mockValues.OVERSEAS_ENTITY_RESOURCE_OBJECT_MOCK.entity_name,
+            presenter: undefined,
+            entity: undefined,
+            due_diligence: undefined,
+            overseas_entity_due_diligence: undefined,
+            beneficial_owners_statement: undefined,
+            beneficial_owners_individual: undefined,
+            beneficial_owners_corporate: undefined,
+            beneficial_owners_government_or_public_authority: undefined,
+            managing_officers_individual: undefined,
+            managing_officers_corporate: undefined,
+            trusts: undefined
+        });
+
+        expect(data.entity_name).to.deep.equal(mockValues.ENTITY_NAME_MOCK);
+        expect(data.presenter).to.deep.equal({});
+        expect(data.entity).to.deep.equal({});
+        expect(data.due_diligence).to.deep.equal({});
+        expect(data.overseas_entity_due_diligence).to.deep.equal({});
+        expect(data.beneficial_owners_statement).to.deep.equal(undefined);
+        expect(data.beneficial_owners_individual).to.deep.equal([]);
+        expect(data.beneficial_owners_corporate).to.deep.equal([]);
+        expect(data.beneficial_owners_government_or_public_authority).to.deep.equal([]);
+        expect(data.managing_officers_individual).to.deep.equal([]);
+        expect(data.managing_officers_corporate).to.deep.equal([]);
+        expect(data.trusts).to.deep.equal([]);
+    });
+
+
     it("should return OverseasEntity object from mapOverseasEntityResource method with just Presenter data", async () => {
         const data = mapOverseasEntityResource({
+            entity_name: undefined,
             presenter: mockValues.OVERSEAS_ENTITY_RESOURCE_OBJECT_MOCK.presenter,
             entity: undefined,
             due_diligence: undefined,
@@ -224,6 +261,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
             trusts: undefined
         });
 
+        expect(data.entity_name).to.deep.equal({});
         expect(data.presenter).to.deep.equal(mockValues.PRESENTER_OBJECT_MOCK);
         expect(data.entity).to.deep.equal({});
         expect(data.due_diligence).to.deep.equal({});


### PR DESCRIPTION
Added a feature branch
Added the Entity_Name
Removed the name field from the exiting entity block

Assumed we want to add the feature branch everywhere and if we are changing existing code then we'll need it.