### PR TITLE
Roe 1945 - TL - entity name mapping post and get

### DIFF
--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -26,7 +26,7 @@ import {
 
 export const mapOverseasEntity = (body: OverseasEntity): OverseasEntityResource => {
     return {
-        entity_name: (body.entity_name) ? body.entity_name : null,
+        entity_name: (body.entity_name) ? { name: body.entity_name } : null,
         entity_number: (body.entity_number) ? body.entity_number : null,
         presenter: (body.presenter && Object.keys(body.presenter).length) ? { ...body.presenter } : null,
         entity: (body.entity && Object.keys(body.entity).length) ? { ...body.entity } : null,
@@ -44,7 +44,7 @@ export const mapOverseasEntity = (body: OverseasEntity): OverseasEntityResource 
 
 export const mapOverseasEntityResource = (body: OverseasEntityResource): OverseasEntity => {
     return {
-        entity_name: body.entity_name,
+        entity_name: (body.entity_name) ? body.entity_name.name : null,
         entity_number: body.entity_number,
         presenter: { ...body.presenter },
         entity: { ...body.entity },

--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -19,7 +19,7 @@ export interface OverseasEntity {
 }
 
 export interface OverseasEntityResource {
-    entity_name?: string;
+    entity_name?: EntityName;
     entity_number?: string;
     presenter?: Presenter;
     entity?: Entity;
@@ -45,6 +45,10 @@ export interface HttpStatusCode {
 /**
  * Overseas Entities interface used on OverseasEntity object
  */
+
+export interface EntityName {
+    name?: string
+}
 
 export interface Presenter {
     full_name?: string

--- a/test/services/overseas-entities/overseas.entities.mock.ts
+++ b/test/services/overseas-entities/overseas.entities.mock.ts
@@ -32,6 +32,7 @@ import {
     TrustHistoricalBeneficialOwner,
     TrustHistoricalBeneficialOwnerResource
 } from "../../../src/services/overseas-entities";
+import { EntityName } from "../../../dist/services/overseas-entities";
 
 export const ADDRESS: Address = {
     property_name_number: "property name 1",
@@ -43,7 +44,11 @@ export const ADDRESS: Address = {
     postcode: "BY 2"
 };
 
-export const ENTITY_NAME_MOCK = "Entity Name";
+export const ENTITY_NAME_BLOCK_MOCK: EntityName = {
+    name: "Entity Name"
+};
+
+export const ENTITY_NAME_FIELD_MOCK = "Entity Name";
 
 export const ENTITY_NUMBER_MOCK = "Entity Number";
 
@@ -333,7 +338,7 @@ export const TRUSTS_MOCK: Trust[] = [{
 }]
 
 export const OVERSEAS_ENTITY_OBJECT_MOCK: OverseasEntity = {
-    entity_name: ENTITY_NAME_MOCK,
+    entity_name: "Entity Name",
     entity_number: ENTITY_NUMBER_MOCK,
     presenter: PRESENTER_OBJECT_MOCK,
     entity: ENTITY_OBJECT_MOCK,
@@ -424,7 +429,7 @@ export const TRUSTS_RESOURCE_MOCK: TrustResource[] = [{
 }]
 
 export const OVERSEAS_ENTITY_RESOURCE_OBJECT_MOCK: OverseasEntityResource = {
-    entity_name: ENTITY_NAME_MOCK,
+    entity_name: ENTITY_NAME_BLOCK_MOCK,
     entity_number: ENTITY_NUMBER_MOCK,
     presenter: PRESENTER_OBJECT_MOCK,
     entity: ENTITY_OBJECT_MOCK,

--- a/test/services/overseas-entities/overseas.entities.mock.ts
+++ b/test/services/overseas-entities/overseas.entities.mock.ts
@@ -338,7 +338,7 @@ export const TRUSTS_MOCK: Trust[] = [{
 }]
 
 export const OVERSEAS_ENTITY_OBJECT_MOCK: OverseasEntity = {
-    entity_name: "Entity Name",
+    entity_name: ENTITY_NAME_FIELD_MOCK,
     entity_number: ENTITY_NUMBER_MOCK,
     presenter: PRESENTER_OBJECT_MOCK,
     entity: ENTITY_OBJECT_MOCK,

--- a/test/services/overseas-entities/overseas.entities.spec.ts
+++ b/test/services/overseas-entities/overseas.entities.spec.ts
@@ -125,7 +125,7 @@ describe("OverseasEntityService GET Tests suite", () => {
 describe("Mapping OverseasEntity Tests suite", () => {
     it("should return OverseasEntityResource object from mapOverseasEntity method", async () => {
         const data = mapOverseasEntity({
-            entity_name: mockValues.ENTITY_NAME_MOCK,
+            entity_name: mockValues.ENTITY_NAME_FIELD_MOCK,
             entity_number: mockValues.ENTITY_NUMBER_MOCK,
             presenter: mockValues.PRESENTER_OBJECT_MOCK,
             entity: mockValues.ENTITY_OBJECT_MOCK,
@@ -205,7 +205,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
             trusts: OE_RESOURCE.trusts
         });
 
-        expect(data.entity_name).to.deep.equal(mockValues.ENTITY_NAME_MOCK);
+        expect(data.entity_name).to.deep.equal(mockValues.ENTITY_NAME_FIELD_MOCK);
         expect(data.entity_number).to.deep.equal(mockValues.ENTITY_NUMBER_MOCK);
         expect(data.presenter).to.deep.equal(mockValues.PRESENTER_OBJECT_MOCK);
         expect(data.entity).to.deep.equal(mockValues.ENTITY_OBJECT_MOCK);
@@ -237,7 +237,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
             trusts: undefined
         });
 
-        expect(data.entity_name).to.deep.equal(mockValues.ENTITY_NAME_MOCK);
+        expect(data.entity_name).to.deep.equal(mockValues.ENTITY_NAME_FIELD_MOCK);
         expect(data.entity_number).to.deep.equal(undefined);
         expect(data.presenter).to.deep.equal({});
         expect(data.entity).to.deep.equal({});
@@ -269,7 +269,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
             trusts: undefined
         });
 
-        expect(data.entity_name).to.deep.equal(undefined);
+        expect(data.entity_name).to.deep.equal(null);
         expect(data.entity_number).to.deep.equal(mockValues.ENTITY_NUMBER_MOCK);
         expect(data.presenter).to.deep.equal({});
         expect(data.entity).to.deep.equal({});
@@ -300,7 +300,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
             trusts: undefined
         });
 
-        expect(data.entity_name).to.deep.equal(undefined);
+        expect(data.entity_name).to.deep.equal(null);
         expect(data.presenter).to.deep.equal(mockValues.PRESENTER_OBJECT_MOCK);
         expect(data.entity).to.deep.equal({});
         expect(data.due_diligence).to.deep.equal({});


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1945 

Updated resource model to mirror the new block in the api.
Map single field to the block when mapping to the resource for POST and vice versa when using GET.