### PR TITLE
ROE-1918: Add extra new corporate BO fields to types and tests

### DIFF
--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -338,6 +338,8 @@ export interface TrustHistoricalBeneficialOwner {
     ceased_date_day?: string;
     ceased_date_month?: string;
     ceased_date_year?: string;
+    corporate_indicator?: boolean;
+    corporate_name?: string;
 }
 
 export interface TrustHistoricalBeneficialOwnerResource {
@@ -346,6 +348,8 @@ export interface TrustHistoricalBeneficialOwnerResource {
     surname?: string;
     notified_date?: string;
     ceased_date?: string;
+    corporate_indicator?: boolean;
+    corporate_name?: string;
 }
 
 export interface TrustCorporate {

--- a/test/services/overseas-entities/overseas.entities.mock.ts
+++ b/test/services/overseas-entities/overseas.entities.mock.ts
@@ -317,6 +317,17 @@ export const TRUST_HISTORICAL_BOS_MOCK: TrustHistoricalBeneficialOwner[] = [{
     forename: "joe",
     other_forenames: "jim",
     surname: "bloggs",
+    corporate_indicator: false,
+    notified_date_day: "13",
+    notified_date_month: "11",
+    notified_date_year: "1985",
+    ceased_date_day: "14",
+    ceased_date_month: "12",
+    ceased_date_year: "1986"
+},
+{
+    corporate_indicator: true,
+    corporate_name: "corp_former_bo",
     notified_date_day: "13",
     notified_date_month: "11",
     notified_date_year: "1985",
@@ -415,7 +426,16 @@ export const TRUST_HISTORICAL_BOS_RESOURCE_MOCK: TrustHistoricalBeneficialOwnerR
     other_forenames: "jim",
     surname: "bloggs",
     notified_date: "1985-11-13",
-    ceased_date: "1986-12-14"
+    ceased_date: "1986-12-14",
+    corporate_indicator: false
+
+},
+{
+    notified_date: "1985-11-13",
+    ceased_date: "1986-12-14",
+    corporate_indicator: true,
+    corporate_name: "corp_former_bo"
+
 }]
 
 export const TRUSTS_RESOURCE_MOCK: TrustResource[] = [{


### PR DESCRIPTION
Jira [ROE-1918](https://companieshouse.atlassian.net/browse/ROE-1918)

Add extra fields for Historic Beneficial Owner (and related test class) to use this for both former individual and former legal entity trustee types

[ROE-1918]: https://companieshouse.atlassian.net/browse/ROE-1918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ