### PR TITLE
BI-12586 Add Material Discrepancies to PSC Discrepancies Report

### DIFF
--- a/src/services/psc-discrepancies-report/service.ts
+++ b/src/services/psc-discrepancies-report/service.ts
@@ -21,11 +21,11 @@ export default class {
         return this.utility.processResponse(resp);
     }
 
-    public async createNewReport (materialDiscrepancyCategories: string[]): PromisedReportResult {
+    public async createNewReport (materialDiscrepancies: string[]): PromisedReportResult {
         const resp = await this.client.httpPost(
             PSC_DISCREPANCY_API_URL,
             {
-                material_discrepancies: materialDiscrepancyCategories,
+                material_discrepancies: materialDiscrepancies,
                 status: "INCOMPLETE"
             });
         return this.utility.processResponse(resp);

--- a/src/services/psc-discrepancies-report/service.ts
+++ b/src/services/psc-discrepancies-report/service.ts
@@ -21,11 +21,11 @@ export default class {
         return this.utility.processResponse(resp);
     }
 
-    public async createNewReport (obligedEntityType: String): PromisedReportResult {
+    public async createNewReport (materialDiscrepancyCategories: string[]): PromisedReportResult {
         const resp = await this.client.httpPost(
             PSC_DISCREPANCY_API_URL,
             {
-                obliged_entity_type: obligedEntityType,
+                material_discrepancies: materialDiscrepancyCategories,
                 status: "INCOMPLETE"
             });
         return this.utility.processResponse(resp);

--- a/src/services/psc-discrepancies-report/types.ts
+++ b/src/services/psc-discrepancies-report/types.ts
@@ -1,4 +1,5 @@
 export interface PSCDiscrepancyReport {
+    material_discrepancies: string[];
     obliged_entity_organisation_name: string;
     obliged_entity_name: string;
     obliged_entity_contact_name: string;

--- a/test/services/psc-discrepancies-report/service.spec.ts
+++ b/test/services/psc-discrepancies-report/service.spec.ts
@@ -16,6 +16,7 @@ const mockResponseBodyComplete: PSCDiscrepancyReport = {
     },
     etag: "fa1774742515a04204dc105520cee4a4b8d2fc37",
     kind: "psc_discrepancy_report#psc_discrepancy_report",
+    material_discrepancies: ["1", "2"],
     obliged_entity_organisation_name: "orgName",
     obliged_entity_telephone_number: "telephone",
     obliged_entity_contact_name: "contactName",
@@ -34,6 +35,7 @@ const mockResponseBodyCreate: any = (
         },
         etag: "0c4cd8b723080d2be59b451e5d258a2215db469f",
         kind: "psc_discrepancy_report#psc_discrepancy_report",
+        material_discrepancies: ["1", "2"],
         obliged_entity_email: "Æ",
         obliged_entity_type: "2"
     }
@@ -44,7 +46,7 @@ const genericApiError: ApiError = {
 };
 
 const REPORT_ID = "REPORT_ID";
-const OBLIGED_ENTITY_TYPE = "5";
+const MATERIAL_DISCREPANCIES = ["1", "2"];
 
 describe("Get Psc Discrepancy Report", () => {
     beforeEach(() => {
@@ -116,6 +118,7 @@ describe("Get Psc Discrepancy Report", () => {
         expect(data.resource.etag).to.equal(mockResponseBodyCreate.etag);
         expect(data.resource.obliged_entity_organisation_name).to.equal(mockResponseBodyCreate.obliged_entity_organisation_name);
         expect(data.resource.kind).to.equal(mockResponseBodyCreate.kind);
+        expect(data.resource.material_discrepancies).to.equal(mockResponseBodyCreate.material_discrepancies);
         expect(data.resource.obliged_entity_name).to.equal(mockResponseBodyCreate.obliged_entity_name);
         expect(data.resource.obliged_entity_contact_name).to.equal(mockResponseBodyCreate.obliged_entity_contact_name);
         expect(data.resource.obliged_entity_email).to.equal(mockResponseBodyCreate.obliged_entity_email);
@@ -152,7 +155,7 @@ describe("Create Psc Discrepancy Report", () => {
 
         const mockProcess = sinon.stub(pscDiscrepancyReportService.utility, "processResponse").resolves(mockResult)
 
-        const result = await pscDiscrepancyReportService.createNewReport(OBLIGED_ENTITY_TYPE);
+        const result = await pscDiscrepancyReportService.createNewReport(MATERIAL_DISCREPANCIES);
 
         expect(result).to.be.equal(mockResult)
 
@@ -168,7 +171,7 @@ describe("Create Psc Discrepancy Report", () => {
         const mockRequest = sinon.stub(requestClient, "httpPost").resolves(mockPostResponse);
 
         const pscDiscrepancyReportService: PscDiscrepancyReportService = new PscDiscrepancyReportService(requestClient);
-        const result = await pscDiscrepancyReportService.createNewReport(OBLIGED_ENTITY_TYPE);
+        const result = await pscDiscrepancyReportService.createNewReport(MATERIAL_DISCREPANCIES);
 
         expect(result.isFailure()).to.be.true;
 
@@ -183,8 +186,8 @@ describe("Create Psc Discrepancy Report", () => {
             error: {
                 errors: [
                     {
-                        error: "obliged_entity_type must be a valid integer.",
-                        location: "obliged_entity_type",
+                        error: "material_discrepancies contains an invalid subfield",
+                        location: "material_discrepancies",
                         location_type: "request-body",
                         type: "ch:validation"
                     }
@@ -192,8 +195,8 @@ describe("Create Psc Discrepancy Report", () => {
             }
         }
         const expectedError: ApiError = {
-            error: "obliged_entity_type must be a valid integer.",
-            location: "obliged_entity_type",
+            error: "material_discrepancies contains an invalid subfield",
+            location: "material_discrepancies",
             locationType: "request-body",
             type: "ch:validation"
         }
@@ -201,7 +204,7 @@ describe("Create Psc Discrepancy Report", () => {
         const mockRequest = sinon.stub(requestClient, "httpPost").resolves(validationError);
 
         const pscDiscrepancyReportService: PscDiscrepancyReportService = new PscDiscrepancyReportService(requestClient);
-        const result = await pscDiscrepancyReportService.createNewReport(OBLIGED_ENTITY_TYPE);
+        const result = await pscDiscrepancyReportService.createNewReport(MATERIAL_DISCREPANCIES);
 
         expect(result.isFailure()).to.be.true;
 
@@ -219,7 +222,7 @@ describe("Create Psc Discrepancy Report", () => {
 
         const mockRequest = sinon.stub(requestClient, "httpPost").resolves(mockPostResponse);
         const pscDiscrepancyReportService: PscDiscrepancyReportService = new PscDiscrepancyReportService(requestClient);
-        const result = await pscDiscrepancyReportService.createNewReport(OBLIGED_ENTITY_TYPE);
+        const result = await pscDiscrepancyReportService.createNewReport(MATERIAL_DISCREPANCIES);
 
         expect(result.isFailure()).to.be.false;
         expect(result.isSuccess()).to.be.true;
@@ -229,6 +232,7 @@ describe("Create Psc Discrepancy Report", () => {
         expect(data.httpStatusCode).to.equal(200);
         expect(data.resource.etag).to.equal(mockResponseBodyCreate.etag);
         expect(data.resource.kind).to.equal(mockResponseBodyCreate.kind);
+        expect(data.resource.material_discrepancies).to.equal(mockResponseBodyCreate.material_discrepancies);
         expect(data.resource.status).to.equal(mockResponseBodyCreate.status);
         expect(data.resource.obliged_entity_type).to.equal(mockResponseBodyCreate.obliged_entity_type);
         expect(data.resource.obliged_entity_email).to.equal(mockResponseBodyCreate.obliged_entity_email);
@@ -310,6 +314,7 @@ describe("Update Psc Discrepancy Report", () => {
         expect(data.httpStatusCode).to.equal(200);
         expect(data.resource.etag).to.equal(mockResponseBodyComplete.etag);
         expect(data.resource.kind).to.equal(mockResponseBodyComplete.kind);
+        expect(data.resource.material_discrepancies).to.equal(mockResponseBodyComplete.material_discrepancies);
         expect(data.resource.status).to.equal(mockResponseBodyComplete.status);
         expect(data.resource.obliged_entity_type).to.equal(mockResponseBodyComplete.obliged_entity_type);
         expect(data.resource.obliged_entity_email).to.equal(mockResponseBodyComplete.obliged_entity_email);

--- a/test/services/psc-discrepancies-report/util.spec.ts
+++ b/test/services/psc-discrepancies-report/util.spec.ts
@@ -15,6 +15,7 @@ const mockSuccessResponse: HttpResponse = {
         },
         etag: "fa1774742515a04204dc105520cee4a4b8d2fc37",
         kind: "psc_discrepancy_report#psc_discrepancy_report",
+        material_discrepancies: ["1", "2"],
         obliged_entity_organisation_name: "orgName",
         obliged_entity_telephone_number: "telephone",
         obliged_entity_contact_name: "contactName",
@@ -42,8 +43,8 @@ const mockApiErrorResponse: HttpResponse = {
     error: {
         errors: [
             {
-                error: "obliged_entity_type must be a valid integer.",
-                location: "obliged_entity_type",
+                error: "material_discrepancies contains an invalid subfield",
+                location: "material_discrepancies",
                 location_type: "request-body",
                 type: "ch:validation"
             }
@@ -103,8 +104,8 @@ describe("Process Response", () => {
 
     it("returns an ApiErrorResponse with ApiErrors matching response body if body does match APIError format", async () => {
         const expectedError: ApiError = {
-            error: "obliged_entity_type must be a valid integer.",
-            location: "obliged_entity_type",
+            error: "material_discrepancies contains an invalid subfield",
+            location: "material_discrepancies",
             locationType: "request-body",
             type: "ch:validation"
         }


### PR DESCRIPTION
Resolves [BI-12586](https://companieshouse.atlassian.net/browse/BI-12586)

- Add material discrepancies into the type definition
- Update call to create report to use material discrepancies

[BI-12586]: https://companieshouse.atlassian.net/browse/BI-12586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ