### PR TITLE
Add file name to account validator response type

### DIFF
--- a/src/services/account-validator/types.ts
+++ b/src/services/account-validator/types.ts
@@ -19,6 +19,7 @@ export interface AccountValidatorResponse {
     status: RequestStatus;
     result: Result;
     fileId: string;
+    fileName: string;
 }
 
 type RequestStatus = "complete" | "pending";


### PR DESCRIPTION
Adds file name to `account-validator-api` response type.
See [this PR](https://github.com/companieshouse/account-validator-api/pull/15) which adds the filename to the reponse.