### PR TITLE
DACT-385-list-of-active-directors

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -20,6 +20,7 @@ import { OverseasEntityService } from "./services/overseas-entities";
 import { CheckoutSearchService } from "./services/order/search/service";
 import OrderItemService from "./services/order/order-item/service";
 import CheckoutItemService from "./services/order/checkout-item/service";
+import OfficerFilingService from "./services/officer-filing/service";
 
 /**
  * ApiClient is the class that all service objects hang off.
@@ -51,6 +52,7 @@ export default class ApiClient {
   public readonly pscDiscrepancyReport: PSCDiscrepanciesReportService;
   public readonly transaction: TransactionService;
   public readonly overseasEntity: OverseasEntityService;
+  public readonly officerFiling: OfficerFilingService;
 
   constructor (readonly apiClient: IHttpClient, readonly accountClient: IHttpClient) {
       // services on the api domain using the apiClient

--- a/src/services/officer-filing/index.ts
+++ b/src/services/officer-filing/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export { default as OfficerFilingService } from "./service";

--- a/src/services/officer-filing/service.ts
+++ b/src/services/officer-filing/service.ts
@@ -1,4 +1,8 @@
 import {
+    ActiveOfficerDetails,
+    ActiveOfficerDetailsResource,
+    Address,
+    AddressResource,
     Tm01Submission,
 } from "./types";
 import { HttpResponse, IHttpClient } from "../../http";
@@ -20,7 +24,70 @@ export default class {
         return resource;
     }
 
+    public async getListActiveDirectorDetails (transactionId: string): Promise<Resource<ActiveOfficerDetails[]> | ApiErrorResponse> {
+        const url = `${this.getPrivateOfficerFilingUrlIncTransactionId(transactionId)}/active-directors-details`;
+        const resp: HttpResponse = await this.client.httpGet(url);
+
+        if (resp.status >= 400) {
+            return { httpStatusCode: resp.status, errors: [resp.error] };
+        }
+
+        const resource: Resource<ActiveOfficerDetails[]> = { httpStatusCode: resp.status };
+
+        resource.resource = this.mapToListActiveOfficerDetails(resp.body);
+
+        return resource;
+    }
+
+
+
+    private mapToListActiveOfficerDetails (officerResourceList: ActiveOfficerDetailsResource[]): ActiveOfficerDetails[] {
+        const officerList: ActiveOfficerDetails[] = [];
+        for (let index = 0; index < officerResourceList.length; index++) {
+            const officerResource: ActiveOfficerDetailsResource = officerResourceList[index];
+            officerList[index] = {
+                foreName1: officerResource.fore_name_1,
+                foreName2: officerResource.fore_name_2,
+                surname: officerResource.surname,
+                occupation: officerResource.occupation,
+                nationality: officerResource.nationality,
+                dateOfBirth: officerResource.date_of_birth,
+                dateOfAppointment: officerResource.date_of_appointment,
+                countryOfResidence: officerResource.country_of_residence,
+                ...(officerResource.service_address && { serviceAddress: this.mapToAddress(officerResource.service_address) }),
+                ...(officerResource.residential_address && { residentialAddress: this.mapToAddress(officerResource.residential_address) }),
+                isCorporate: officerResource.is_corporate,
+                role: officerResource.role,
+                placeRegistered: officerResource.place_registered,
+                registrationNumber: officerResource.registration_number,
+                lawGoverned: officerResource.law_governed,
+                legalForm: officerResource.legal_form,
+                identificationType: officerResource.identification_type
+            }
+        }
+        return officerList;
+    }
+
+    private mapToAddress (addressResource: AddressResource): Address {
+        return {
+            addressLine1: addressResource.address_line_1,
+            addressLine2: addressResource.address_line_2,
+            careOf: addressResource.care_of,
+            country: addressResource.country,
+            locality: addressResource.locality,
+            poBox: addressResource.po_box,
+            postalCode: addressResource.postal_code,
+            premises: addressResource.premises,
+            region: addressResource.region
+        }
+    }
+
+
     private getOfficerFilingUrlIncTransactionId (transactionId: string) {
         return `/transactions/${transactionId}/officers`;
+    }
+
+    private getPrivateOfficerFilingUrlIncTransactionId (transactionId: string) {
+        return `private/transactions/${transactionId}/officers`;
     }
 }

--- a/src/services/officer-filing/service.ts
+++ b/src/services/officer-filing/service.ts
@@ -11,19 +11,6 @@ import Resource, { ApiErrorResponse } from "../resource";
 export default class {
     constructor (private readonly client: IHttpClient) { }
 
-    public async postTm01 (transactionId: string,
-        tm01Submission: Tm01Submission): Promise<Resource<Tm01Submission> | ApiErrorResponse> {
-        const baseUrl = this.getOfficerFilingUrlIncTransactionId(transactionId);
-        const resp: HttpResponse =
-            await this.client.httpPost(`${baseUrl}`,tm01Submission);
-
-        const resource: Resource<String> = {
-            httpStatusCode: resp.status,
-            resource: resp.body
-        };
-        return resource;
-    }
-
     public async getListActiveDirectorDetails (transactionId: string): Promise<Resource<ActiveOfficerDetails[]> | ApiErrorResponse> {
         const url = `${this.getPrivateOfficerFilingUrlIncTransactionId(transactionId)}/active-directors-details`;
         const resp: HttpResponse = await this.client.httpGet(url);

--- a/src/services/officer-filing/service.ts
+++ b/src/services/officer-filing/service.ts
@@ -1,0 +1,26 @@
+import {
+    Tm01Submission,
+} from "./types";
+import { HttpResponse, IHttpClient } from "../../http";
+import Resource, { ApiErrorResponse } from "../resource";
+
+export default class {
+    constructor (private readonly client: IHttpClient) { }
+
+    public async postTm01 (transactionId: string,
+        tm01Submission: Tm01Submission): Promise<Resource<Tm01Submission> | ApiErrorResponse> {
+        const baseUrl = this.getOfficerFilingUrlIncTransactionId(transactionId);
+        const resp: HttpResponse =
+            await this.client.httpPost(`${baseUrl}`,tm01Submission);
+
+        const resource: Resource<String> = {
+            httpStatusCode: resp.status,
+            resource: resp.body
+        };
+        return resource;
+    }
+
+    private getOfficerFilingUrlIncTransactionId (transactionId: string) {
+        return `/transactions/${transactionId}/officers`;
+    }
+}

--- a/src/services/officer-filing/types.ts
+++ b/src/services/officer-filing/types.ts
@@ -1,0 +1,5 @@
+export interface Tm01Submission {
+    resigned_on: Date,
+    reference_etag: String,
+    reference_appointment_id: String
+}

--- a/src/services/officer-filing/types.ts
+++ b/src/services/officer-filing/types.ts
@@ -3,3 +3,67 @@ export interface Tm01Submission {
     reference_etag: String,
     reference_appointment_id: String
 }
+
+export interface ActiveOfficerDetails {
+    foreName1: string;
+    foreName2?: string;
+    surname: string;
+    occupation: string;
+    nationality: string;
+    dateOfBirth: string;
+    dateOfAppointment: string;
+    countryOfResidence: string;
+    serviceAddress: Address;
+    residentialAddress: Address;
+    isCorporate: boolean;
+    role: string;
+    placeRegistered?: string;
+    registrationNumber?: string;
+    lawGoverned?: string;
+    legalForm?: string;
+    identificationType?: string;
+}
+
+export interface ActiveOfficerDetailsResource {
+    fore_name_1: string;
+    fore_name_2?: string;
+    surname: string;
+    occupation: string;
+    nationality: string;
+    date_of_birth: string;
+    date_of_appointment: string;
+    country_of_residence: string;
+    service_address: AddressResource;
+    residential_address: AddressResource;
+    is_corporate: boolean;
+    role: string;
+    place_registered?: string;
+    registration_number?: string;
+    law_governed?: string;
+    legal_form?: string;
+    identification_type?: string;
+}
+
+export interface Address {
+    addressLine1?: string;
+    addressLine2?: string;
+    careOf?: string;
+    country?: string;
+    locality?: string;
+    poBox?: string;
+    postalCode?: string;
+    premises?: string;
+    region?: string;
+}
+
+export interface AddressResource {
+    address_line_1?: string;
+    address_line_2?: string;
+    care_of?: string;
+    country?: string;
+    locality?: string;
+    po_box?: string;
+    postal_code?: string;
+    premises?: string;
+    region?: string;
+}

--- a/test/services/officer-filing/officer.filing.mock.ts
+++ b/test/services/officer-filing/officer.filing.mock.ts
@@ -1,0 +1,99 @@
+import {
+    ActiveOfficerDetailsResource,
+} from "../../../src/services/officer-filing";
+import { RequestClient } from "../../../src";
+
+export const requestClient = new RequestClient({ baseUrl: "URL_NOT_USED", oauthToken: "TOKEN_NOT_USED" });
+
+export const mockAddress1 = {
+    address_line_1: "20 Any road",
+    address_line_2: "Any",
+    care_of: "xyz",
+    country: "Anyland",
+    locality: "Anytown",
+    po_box: "1",
+    postal_code: "AN1 1XY",
+    premises: "20",
+    region: "Anyshire"
+};
+
+export const mockAddress2 = {
+    address_line_1: "10 This road",
+    address_line_2: "This",
+    care_of: "abc",
+    country: "Thisland",
+    locality: "Thistown",
+    po_box: "1",
+    postal_code: "TH1 1AB",
+    premises: "10",
+    region: "Thisshire"
+};
+
+
+
+export const mockActiveOfficerDetails: ActiveOfficerDetailsResource = {
+    fore_name_1: "John",
+    fore_name_2: "middle name",
+    surname: "Doe",
+    occupation: "singer",
+    nationality: "British",
+    date_of_birth: "1 January 1960",
+    date_of_appointment: "1 January 2009",
+    country_of_residence: "Country",
+    service_address: mockAddress1,
+    residential_address: mockAddress2,
+    is_corporate: false,
+    role: "SECRETARY",
+    place_registered: "UNITED KINGDOM",
+    registration_number: "012345678",
+    law_governed: "INTERNATIONAL BUSINESS COMPANIES ACT 2000",
+    legal_form: "INTERNATIONAL BUSINESS COMPANY",
+    identification_type: "Y"
+}
+
+export const mockListActiveOfficerDetails: ActiveOfficerDetailsResource[] = [
+    {
+        fore_name_1: "John",
+        fore_name_2: "middle name",
+        surname: "Doe",
+        occupation: "singer",
+        nationality: "British",
+        date_of_birth: "1 January 1960",
+        date_of_appointment: "1 January 2009",
+        country_of_residence: "Country",
+        service_address: mockAddress1,
+        residential_address: mockAddress2,
+        is_corporate: false,
+        role: "SECRETARY",
+        place_registered: "UNITED KINGDOM",
+        registration_number: "012345678",
+        law_governed: "INTERNATIONAL BUSINESS COMPANIES ACT 2000",
+        legal_form: "INTERNATIONAL BUSINESS COMPANY",
+        identification_type: "Y"
+    },
+    {
+        fore_name_1: "John",
+        fore_name_2: "middle name",
+        surname: "Doe",
+        occupation: "singer",
+        nationality: "British",
+        date_of_birth: "1 January 1960",
+        date_of_appointment: "1 January 2009",
+        country_of_residence: "Country",
+        service_address: mockAddress1,
+        residential_address: mockAddress2,
+        is_corporate: false,
+        role: "SECRETARY",
+        place_registered: "UNITED KINGDOM",
+        registration_number: "012345678",
+        law_governed: "INTERNATIONAL BUSINESS COMPANIES ACT 2000",
+        legal_form: "INTERNATIONAL BUSINESS COMPANY",
+        identification_type: "Y"
+    }
+]
+
+export const mockGetListActiveOfficersDetails = {
+    200: { status: 200, body: mockListActiveOfficerDetails },
+    404: { status: 404, error: "No active officers details were found" },
+    500: { status: 500, error: "Internal server error" }
+};

--- a/test/services/officer-filing/officer.filing.spec.ts
+++ b/test/services/officer-filing/officer.filing.spec.ts
@@ -1,0 +1,53 @@
+import {
+    ActiveOfficerDetails, OfficerFilingService,
+} from "../../../src/services/officer-filing";
+import * as mockValues from "./officer.filing.mock";
+import { expect } from "chai";
+import sinon from "sinon";
+import Resource, { ApiErrorResponse } from "../../../src/services/resource";
+
+const TRANSACTION_ID = "12345";
+const CONFIRMATION_STATEMENT_ID = "r4nd0m";
+const COMPANY_NUMBER = "11111111";
+
+beforeEach(() => {
+    sinon.reset();
+    sinon.restore();
+});
+
+afterEach(done => {
+    sinon.reset();
+    sinon.restore();
+    done();
+});
+
+
+describe("List active Directors details GET", () => {
+    it("should return active officer details object", async () => {
+        sinon.stub(mockValues.requestClient, "httpGet").resolves(mockValues.mockGetListActiveOfficersDetails[200]);
+        const ofService: OfficerFilingService = new OfficerFilingService(mockValues.requestClient);
+        const data: Resource<ActiveOfficerDetails[]> = await ofService.getListActiveDirectorDetails(TRANSACTION_ID) as Resource<ActiveOfficerDetails[]>;
+
+        expect(data.httpStatusCode).to.equal(200);
+        expect(data.resource[1].dateOfBirth).to.equal(mockValues.mockActiveOfficerDetails.date_of_birth);
+    });
+
+    it("should return error 404 - No active director details were found", async () => {
+        sinon.stub(mockValues.requestClient, "httpGet").resolves(mockValues.mockGetListActiveOfficersDetails[404]);
+        const ofService: OfficerFilingService = new OfficerFilingService(mockValues.requestClient);
+        const data: ApiErrorResponse = await ofService.getListActiveDirectorDetails(TRANSACTION_ID);
+
+        expect(data.httpStatusCode).to.equal(404);
+        expect(data.errors[0]).to.equal("No active officers details were found");
+    });
+
+    it("should return error 500 - Internal server error", async () => {
+        sinon.stub(mockValues.requestClient, "httpGet").resolves(mockValues.mockGetListActiveOfficersDetails[500]);
+        const ofService: OfficerFilingService = new OfficerFilingService(mockValues.requestClient);
+        const data: ApiErrorResponse = await ofService.getListActiveDirectorDetails(TRANSACTION_ID);
+
+        expect(data.httpStatusCode).to.equal(500);
+        expect(data.errors[0]).to.equal("Internal server error");
+    });
+
+});


### PR DESCRIPTION
The current directors page is the 6th page in the happy path journey for the web service. It acts as a page where an Officer may select from a list of active directors associated with a company to remove.

An Officer should be able to click the remove director link which will take them to the ‘When was this director removed ?’ (removal date) page.

To complete this work, we first need an endpoint to retrieve the list of active Directors.