### PR TITLE
Chore: Standardise axios integration options

### DIFF
--- a/src/http/request-client.ts
+++ b/src/http/request-client.ts
@@ -31,13 +31,13 @@ export default class RequestClient extends AbstractClient {
             const options: AxiosRequestConfig = {
                 method: additionalOptions.method,
                 headers: {
-                    ...this.headers,
-                    ...additionalOptions.headers
+                    authorization: this.headers.Authorization,
+                    accept: "application/json",
+                    "content-type": "application/json"
                 },
                 url: `${this.options.baseUrl}${additionalOptions.url}`,
                 data: additionalOptions.body,
-                responseType: "json",
-                validateStatus: () => true
+                responseType: "json"
             };
 
             // any errors (including status code errors) are thrown as exceptions and


### PR DESCRIPTION
- Standardises `axios` integration options to include explicit header fields
- Removes status validator so as to implicitly use status in response