### PR TITLE
Fix: Check incoming uri for missing leading slash

### DIFF
--- a/src/http/request-client.ts
+++ b/src/http/request-client.ts
@@ -35,7 +35,7 @@ export default class RequestClient extends AbstractClient {
                     accept: "application/json",
                     "content-type": "application/json"
                 },
-                url: `${this.options.baseUrl}${additionalOptions.url}`,
+                url: this.formatUrl(this.options.baseUrl, additionalOptions.url),
                 data: additionalOptions.body,
                 responseType: "json"
             };
@@ -57,5 +57,12 @@ export default class RequestClient extends AbstractClient {
                 error
             };
         }
+    }
+
+    private formatUrl (baseUrl, uri) {
+        if (uri.charAt(0) !== "/") {
+            uri = `/${uri}`;
+        }
+        return `${baseUrl}${uri}`;
     }
 }

--- a/test/http/request-client.spec.ts
+++ b/test/http/request-client.spec.ts
@@ -7,7 +7,8 @@ import { RequestClient, HttpResponse } from "../../src/http";
 const expect = chai.expect;
 
 describe("request-client", () => {
-    const client = new RequestClient({ baseUrl: "http://api", oauthToken: "123" });
+    const baseUrl: string = "http://api";
+    const client = new RequestClient({ oauthToken: "123", baseUrl });
 
     beforeEach(() => {
         sinon.reset();
@@ -191,5 +192,17 @@ describe("request-client", () => {
         expect(mockRequest).to.have.been.calledOnce;
         expect(resp.error).to.be.undefined;
         expect(resp.status).to.equal(statusCode);
+    });
+
+    it("returns a correctly formatted url if leading slash is missing in the uri", () => {
+        const clientPrototype = Object.getPrototypeOf(client);
+        const formattedUrl = clientPrototype.formatUrl(baseUrl, "path/to/end-point");
+        expect(formattedUrl).to.equal(`${baseUrl}/path/to/end-point`);
+    });
+
+    it("returns a correctly formatted url if leading slash is present in the uri", () => {
+        const clientPrototype = Object.getPrototypeOf(client);
+        const formattedUrl = clientPrototype.formatUrl(baseUrl, "/path/to/end-point");
+        expect(formattedUrl).to.equal(`${baseUrl}/path/to/end-point`);
     });
 });


### PR DESCRIPTION
 Checks the `uri` passed in for a leading slash and adds it in if it's missing.