### PR TITLE
Fix: Return fully qualified url without trailing slash

### DIFF
--- a/src/http/request-client.ts
+++ b/src/http/request-client.ts
@@ -59,9 +59,12 @@ export default class RequestClient extends AbstractClient {
         }
     }
 
-    private formatUrl (baseUrl, uri) {
-        if (uri.charAt(0) !== "/") {
+    private formatUrl (baseUrl: string, uri: string) {
+        if (uri.length > 0 && uri.charAt(0) !== "/") {
             uri = `/${uri}`;
+        }
+        if (uri === "/") {
+            return baseUrl;
         }
         return `${baseUrl}${uri}`;
     }

--- a/test/http/request-client.spec.ts
+++ b/test/http/request-client.spec.ts
@@ -205,4 +205,16 @@ describe("request-client", () => {
         const formattedUrl = clientPrototype.formatUrl(baseUrl, "/path/to/end-point");
         expect(formattedUrl).to.equal(`${baseUrl}/path/to/end-point`);
     });
+
+    it("returns a correctly formatted url if uri contains only a slash", () => {
+        const clientPrototype = Object.getPrototypeOf(client);
+        const formattedUrl = clientPrototype.formatUrl(baseUrl, "/");
+        expect(formattedUrl).to.equal(`${baseUrl}`);
+    });
+
+    it("returns a correctly formatted url if uri is empty", () => {
+        const clientPrototype = Object.getPrototypeOf(client);
+        const formattedUrl = clientPrototype.formatUrl(baseUrl, "");
+        expect(formattedUrl).to.equal(`${baseUrl}`);
+    });
 });


### PR DESCRIPTION
- Returns a fully qualified url without a trailing slash
- Extends tests to account for additional logic