### PR TITLE
DACT-410: Dissolved stop screen

### DIFF
--- a/src/services/officer-filing/service.ts
+++ b/src/services/officer-filing/service.ts
@@ -38,8 +38,6 @@ export default class {
             return { httpStatusCode: resp.status, errors: [resp.error] };
         }
 
-        const resource: Resource<Boolean> = { httpStatusCode: resp.status, resource: resp.body == 'true' };
-
-        return resource;
+        return { httpStatusCode: resp.status, resource: resp.body as Boolean };
     }
 }

--- a/src/services/officer-filing/service.ts
+++ b/src/services/officer-filing/service.ts
@@ -29,4 +29,17 @@ export default class {
     private getOfficerFilingUrlIncTransactionId (transactionId: string) {
         return `/transactions/${transactionId}/officers`;
     }
+
+    public async getCurrentOrFutureDissolved (companyNumber: String, transactionId: string): Promise<Resource<Boolean>> | ApiErrorResponse> {
+        const url = `/transactions/${transactionId}/company/${companyNumber}/past-future-dissolved`;
+        const resp: HttpResponse = await this.client.httpGet(url);
+
+        if (resp.status >= 400) {
+            return { httpStatusCode: resp.status, errors: [resp.error] };
+        }
+
+        const resource: Resource<Boolean> = { httpStatusCode: resp.status, resource: parseBoolean(resp.body) };
+
+        return resource;
+    }
 }

--- a/src/services/officer-filing/service.ts
+++ b/src/services/officer-filing/service.ts
@@ -30,8 +30,8 @@ export default class {
         return `/transactions/${transactionId}/officers`;
     }
 
-    public async getCurrentOrFutureDissolved (companyNumber: String, transactionId: string): Promise<Resource<Boolean> | ApiErrorResponse> {
-        const url = `/transactions/${transactionId}/company/${companyNumber}/past-future-dissolved`;
+    public async getCurrentOrFutureDissolved (companyNumber: String): Promise<Resource<Boolean> | ApiErrorResponse> {
+        const url = `/officer-filing/company/${companyNumber}/stop-screen-checks/past-future-dissolved`;
         const resp: HttpResponse = await this.client.httpGet(url);
 
         if (resp.status >= 400) {

--- a/src/services/officer-filing/service.ts
+++ b/src/services/officer-filing/service.ts
@@ -30,7 +30,7 @@ export default class {
         return `/transactions/${transactionId}/officers`;
     }
 
-    public async getCurrentOrFutureDissolved (companyNumber: String, transactionId: string): Promise<Resource<Boolean>> | ApiErrorResponse> {
+    public async getCurrentOrFutureDissolved (companyNumber: String, transactionId: string): Promise<Resource<Boolean> | ApiErrorResponse> {
         const url = `/transactions/${transactionId}/company/${companyNumber}/past-future-dissolved`;
         const resp: HttpResponse = await this.client.httpGet(url);
 
@@ -38,7 +38,7 @@ export default class {
             return { httpStatusCode: resp.status, errors: [resp.error] };
         }
 
-        const resource: Resource<Boolean> = { httpStatusCode: resp.status, resource: parseBoolean(resp.body) };
+        const resource: Resource<Boolean> = { httpStatusCode: resp.status, resource: resp.body == 'true' };
 
         return resource;
     }

--- a/src/services/officer-filing/service.ts
+++ b/src/services/officer-filing/service.ts
@@ -31,7 +31,7 @@ export default class {
     }
 
     public async getCurrentOrFutureDissolved (companyNumber: String): Promise<Resource<Boolean> | ApiErrorResponse> {
-        const url = `/officer-filing/company/${companyNumber}/stop-screen-checks/past-future-dissolved`;
+        const url = `/officer-filing/company/${companyNumber}/eligibility-check/past-future-dissolved`;
         const resp: HttpResponse = await this.client.httpGet(url);
 
         if (resp.status >= 400) {

--- a/test/services/officer-filing/officer.filing.mock.ts
+++ b/test/services/officer-filing/officer.filing.mock.ts
@@ -93,3 +93,12 @@ export const mockGetListActiveDirectorsDetails = {
     404: { status: 404, error: "No active directors details were found" },
     500: { status: 500, error: "Internal server error" }
 };
+
+export const mockGetCurrentOrFutureDissolved = {
+    200: { status: 200, body: true },
+    500: { status: 500, error: "Internal server error" }
+}
+
+export const mockGetCurrentOrFutureDissolvedReturnsFalse = {
+    200: { status: 200, body: false }
+}

--- a/test/services/officer-filing/officer.filing.spec.ts
+++ b/test/services/officer-filing/officer.filing.spec.ts
@@ -7,6 +7,7 @@ import sinon from "sinon";
 import Resource, { ApiErrorResponse } from "../../../src/services/resource";
 
 const TRANSACTION_ID = "12345";
+const COMPANY_NUMBER = "00006400";
 
 beforeEach(() => {
     sinon.reset();
@@ -42,6 +43,35 @@ describe("List active Directors details GET", () => {
         sinon.stub(mockValues.requestClient, "httpGet").resolves(mockValues.mockGetListActiveDirectorsDetails[500]);
         const ofService: OfficerFilingService = new OfficerFilingService(mockValues.requestClient);
         const data: ApiErrorResponse = await ofService.getListActiveDirectorDetails(TRANSACTION_ID);
+
+        expect(data.httpStatusCode).to.equal(500);
+        expect(data.errors[0]).to.equal("Internal server error");
+    });
+});
+
+describe("Current or future dissolved GET", () => {
+    it("should return Boolean value", async () => {
+        sinon.stub(mockValues.requestClient, "httpGet").resolves(mockValues.mockGetCurrentOrFutureDissolved[200]);
+        const ofService: OfficerFilingService = new OfficerFilingService(mockValues.requestClient);
+        const data: Resource<Boolean> = await ofService.getCurrentOrFutureDissolved(COMPANY_NUMBER) as Resource<Boolean>;
+
+        expect(data.httpStatusCode).to.equal(200);
+        expect(data.resource).to.equal(true);
+    });
+
+    it("should return Boolean value of false", async () => {
+        sinon.stub(mockValues.requestClient, "httpGet").resolves(mockValues.mockGetCurrentOrFutureDissolvedReturnsFalse[200]);
+        const ofService: OfficerFilingService = new OfficerFilingService(mockValues.requestClient);
+        const data: Resource<Boolean> = await ofService.getCurrentOrFutureDissolved(COMPANY_NUMBER) as Resource<Boolean>;
+
+        expect(data.httpStatusCode).to.equal(200);
+        expect(data.resource).to.equal(false);
+    });
+
+    it("should return error 500 - Internal server error", async () => {
+        sinon.stub(mockValues.requestClient, "httpGet").resolves(mockValues.mockGetCurrentOrFutureDissolved[500]);
+        const ofService: OfficerFilingService = new OfficerFilingService(mockValues.requestClient);
+        const data: ApiErrorResponse = await ofService.getCurrentOrFutureDissolved(COMPANY_NUMBER);
 
         expect(data.httpStatusCode).to.equal(500);
         expect(data.errors[0]).to.equal("Internal server error");


### PR DESCRIPTION
Officer Filing - Logic to enable dissolved company stop screen 
[DACT-410] (https://companieshouse.atlassian.net/browse/DACT-410):

- Added officer-filing-api getCurrentOrFutureDissolved method call

[DACT-410]: https://companieshouse.atlassian.net/browse/DACT-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ