### PR TITLE
UAR-616: Retrieve private OE details

### DIFF
--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -25,7 +25,8 @@ import {
     TrustCorporate,
     TrustCorporateResource,
     Update,
-    UpdateResource
+    UpdateResource,
+    OverseasEntityExtraDetails
 } from "./types";
 
 export const mapOverseasEntity = (body: OverseasEntity): OverseasEntityResource => {
@@ -69,6 +70,12 @@ export const mapOverseasEntityResource = (body: OverseasEntityResource): Oversea
         managing_officers_corporate: (body.managing_officers_corporate || []).map(mapMocResource),
         trusts: mapTrustsResource(body.trusts),
         update: mapUpdateResource(body.update)
+    };
+};
+
+export const mapOverseasEntityExtraDetails = (body: OverseasEntityExtraDetails): OverseasEntityExtraDetails => {
+    return {
+        email_address: (body.email_address)
     };
 };
 

--- a/src/services/overseas-entities/service.ts
+++ b/src/services/overseas-entities/service.ts
@@ -2,10 +2,11 @@ import { HttpResponse, IHttpClient } from "../../http";
 import {
     HttpStatusCode,
     OverseasEntity,
-    OverseasEntityCreated
+    OverseasEntityCreated,
+    OverseasEntityExtraDetails,
 } from "./types";
 import Resource, { ApiErrorResponse } from "../resource";
-import { mapOverseasEntity, mapOverseasEntityResource } from "./mapping";
+import { mapOverseasEntity, mapOverseasEntityExtraDetails, mapOverseasEntityResource } from "./mapping";
 
 export default class OverseasEntityService {
     constructor (private readonly client: IHttpClient) { }
@@ -24,6 +25,25 @@ export default class OverseasEntityService {
         const resource: Resource<OverseasEntity> = {
             httpStatusCode: response.status,
             resource: mapOverseasEntityResource(response.body)
+        };
+
+        return resource;
+    }
+
+    public async getOverseasEntityDetails (companyNumber: string): Promise< Resource<OverseasEntity> | ApiErrorResponse > {
+        const URL = `overseas-entity-details/${companyNumber}`
+        const response: HttpResponse = await this.client.httpGet(URL);
+
+        if (response.error) {
+            return {
+                httpStatusCode: response.status,
+                errors: [response.error]
+            };
+        }
+
+        const resource: Resource<OverseasEntityExtraDetails> = {
+            httpStatusCode: response.status,
+            resource: mapOverseasEntityExtraDetails(response.body)
         };
 
         return resource;
@@ -67,5 +87,5 @@ export default class OverseasEntityService {
         }
 
         return { httpStatusCode: resp.status }
-    }
+    } 
 }

--- a/src/services/overseas-entities/service.ts
+++ b/src/services/overseas-entities/service.ts
@@ -3,7 +3,7 @@ import {
     HttpStatusCode,
     OverseasEntity,
     OverseasEntityCreated,
-    OverseasEntityExtraDetails,
+    OverseasEntityExtraDetails
 } from "./types";
 import Resource, { ApiErrorResponse } from "../resource";
 import { mapOverseasEntity, mapOverseasEntityExtraDetails, mapOverseasEntityResource } from "./mapping";
@@ -86,6 +86,6 @@ export default class OverseasEntityService {
             };
         }
 
-        return { httpStatusCode: resp.status }
-    } 
+        return { httpStatusCode: resp.status };
+    }
 }

--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -36,6 +36,10 @@ export interface OverseasEntityResource {
     update?: UpdateResource;
 }
 
+export interface OverseasEntityExtraDetails {
+    email_address: string;
+}
+
 export interface OverseasEntityCreated {
     id: string
 }

--- a/test/services/overseas-entities/overseas.entities.mock.ts
+++ b/test/services/overseas-entities/overseas.entities.mock.ts
@@ -414,7 +414,7 @@ export const OVERSEAS_ENTITY_OBJECT_MOCK: OverseasEntity = {
 };
 
 export const OVERSEAS_ENTITY_EXTRA_DETAILS_OBJECT_MOCK: OverseasEntityExtraDetails = {
-    email_address: 'private@overseasentities.test',
+    email_address: "private@overseasentities.test"
 };
 
 export const TRUST_INDIVIDUALS_RESOURCE_MOCK: TrustIndividualResource[] = [{
@@ -523,7 +523,7 @@ export const OVERSEAS_ENTITY_RESOURCE_OBJECT_MOCK: OverseasEntityResource = {
 };
 
 export const OVERSEAS_ENTITY_EXTRA_DETAILS_RESOURCE_MOCK: OverseasEntityExtraDetails = {
-    email_address: 'private@overseasentities.test',
+    email_address: "private@overseasentities.test"
 };
 
 export const requestClient = new RequestClient({ baseUrl: "URL_NOT_USED", oauthToken: "TOKEN_NOT_USED" });
@@ -552,5 +552,5 @@ export const mockGetOverseasEntityResponse = {
 
 export const mockGetOverseasEntityExtraDetailsResponse = {
     200: { status: 200, body: OVERSEAS_ENTITY_EXTRA_DETAILS_RESOURCE_MOCK },
-    400: { status: 400, error: BAD_REQUEST },
+    400: { status: 400, error: BAD_REQUEST }
 };

--- a/test/services/overseas-entities/overseas.entities.mock.ts
+++ b/test/services/overseas-entities/overseas.entities.mock.ts
@@ -33,7 +33,8 @@ import {
     TrustHistoricalBeneficialOwner,
     TrustHistoricalBeneficialOwnerResource,
     Update,
-    UpdateResource
+    UpdateResource,
+    OverseasEntityExtraDetails
 } from "../../../src/services/overseas-entities";
 
 export const ADDRESS: Address = {
@@ -412,6 +413,10 @@ export const OVERSEAS_ENTITY_OBJECT_MOCK: OverseasEntity = {
     update: UPDATE_OBJECT_MOCK
 };
 
+export const OVERSEAS_ENTITY_EXTRA_DETAILS_OBJECT_MOCK: OverseasEntityExtraDetails = {
+    email_address: 'private@overseasentities.test',
+};
+
 export const TRUST_INDIVIDUALS_RESOURCE_MOCK: TrustIndividualResource[] = [{
     type: "type",
     forename: "joe",
@@ -517,6 +522,10 @@ export const OVERSEAS_ENTITY_RESOURCE_OBJECT_MOCK: OverseasEntityResource = {
     update: UPDATE_RESOURCE_MOCK
 };
 
+export const OVERSEAS_ENTITY_EXTRA_DETAILS_RESOURCE_MOCK: OverseasEntityExtraDetails = {
+    email_address: 'private@overseasentities.test',
+};
+
 export const requestClient = new RequestClient({ baseUrl: "URL_NOT_USED", oauthToken: "TOKEN_NOT_USED" });
 
 export const TRANSACTION_ID = "12345";
@@ -539,4 +548,9 @@ export const mockPutOverseasEntityResponse = {
 export const mockGetOverseasEntityResponse = {
     200: { status: 200, body: OVERSEAS_ENTITY_RESOURCE_OBJECT_MOCK },
     400: { status: 400, error: BAD_REQUEST }
+};
+
+export const mockGetOverseasEntityExtraDetailsResponse = {
+    200: { status: 200, body: OVERSEAS_ENTITY_EXTRA_DETAILS_RESOURCE_MOCK },
+    400: { status: 400, error: BAD_REQUEST },
 };

--- a/test/services/overseas-entities/overseas.entities.spec.ts
+++ b/test/services/overseas-entities/overseas.entities.spec.ts
@@ -480,15 +480,15 @@ describe("Mapping OverseasEntity Tests suite", () => {
         expect(Object.keys(dataResource.overseas_entity_due_diligence!).indexOf("identity_date")).to.equal(-1);
     });
 
-    it('should return OE extra details object with email address', () => {
+    it("should return OE extra details object with email address", () => {
         const dataResource = mapOverseasEntityExtraDetails({
-            email_address: 'private@overseasentities.test',
+            email_address: "private@overseasentities.test"
         });
 
-        expect(dataResource.email_address).to.equal('private@overseasentities.test');
+        expect(dataResource.email_address).to.equal("private@overseasentities.test");
     });
 
-    it('should return OE extra details object without email address if empty', () => {
+    it("should return OE extra details object without email address if empty", () => {
         const dataResource = mapOverseasEntityExtraDetails({} as OverseasEntityExtraDetails);
 
         expect(dataResource.email_address).to.equal(undefined);

--- a/test/services/overseas-entities/overseas.entities.spec.ts
+++ b/test/services/overseas-entities/overseas.entities.spec.ts
@@ -6,10 +6,11 @@ import * as mockValues from "./overseas.entities.mock";
 import {
     BeneficialOwnersStatementType,
     OverseasEntityCreated,
+    OverseasEntityExtraDetails,
     OverseasEntityService
 } from "../../../src/services/overseas-entities";
 import Resource, { ApiErrorResponse } from "../../../src/services/resource";
-import { mapOverseasEntity, mapOverseasEntityResource } from "../../../src/services/overseas-entities/mapping";
+import { mapOverseasEntity, mapOverseasEntityResource, mapOverseasEntityExtraDetails } from "../../../src/services/overseas-entities/mapping";
 
 describe("OverseasEntityService POST Tests suite", () => {
     beforeEach(() => {
@@ -115,6 +116,30 @@ describe("OverseasEntityService GET Tests suite", () => {
         const data = await oeService.getOverseasEntity(
             mockValues.TRANSACTION_ID,
             mockValues.OVERSEAS_ENTITY_ID
+        ) as ApiErrorResponse;
+
+        expect(data.httpStatusCode).to.equal(400);
+        expect(data.errors![0]).to.deep.equal(mockValues.BAD_REQUEST);
+    });
+
+    it("should return httpStatusCode 200 for getOverseasEntityDetails method", async () => {
+        sinon.stub(mockValues.requestClient, "httpGet").resolves(mockValues.mockGetOverseasEntityExtraDetailsResponse[200]);
+
+        const oeService = new OverseasEntityService(mockValues.requestClient);
+        const data = (await oeService.getOverseasEntityDetails(
+            mockValues.ENTITY_NUMBER_MOCK
+        )) as Resource<OverseasEntityExtraDetails>;
+
+        expect(data.httpStatusCode).to.equal(200);
+        expect(data.resource).to.deep.equal(mockValues.OVERSEAS_ENTITY_EXTRA_DETAILS_OBJECT_MOCK);
+    });
+
+    it("should return error 400 (Bad Request) for getOverseasEntityDetails method", async () => {
+        sinon.stub(mockValues.requestClient, "httpGet").resolves(mockValues.mockGetOverseasEntityExtraDetailsResponse[400]);
+
+        const oeService = new OverseasEntityService(mockValues.requestClient);
+        const data = await oeService.getOverseasEntityDetails(
+            mockValues.ENTITY_NUMBER_MOCK
         ) as ApiErrorResponse;
 
         expect(data.httpStatusCode).to.equal(400);
@@ -453,5 +478,19 @@ describe("Mapping OverseasEntity Tests suite", () => {
         });
 
         expect(Object.keys(dataResource.overseas_entity_due_diligence!).indexOf("identity_date")).to.equal(-1);
+    });
+
+    it('should return OE extra details object with email address', () => {
+        const dataResource = mapOverseasEntityExtraDetails({
+            email_address: 'private@overseasentities.test',
+        });
+
+        expect(dataResource.email_address).to.equal('private@overseasentities.test');
+    });
+
+    it('should return OE extra details object without email address if empty', () => {
+        const dataResource = mapOverseasEntityExtraDetails({} as OverseasEntityExtraDetails);
+
+        expect(dataResource.email_address).to.equal(undefined);
     });
 });


### PR DESCRIPTION
### JIRA:

https://companieshouse.atlassian.net/browse/UAR-616

### Changes:
- Added `getOverseasEntityDetails` endpoint to OE service to retrieve private OE details

### Associated PRs:
- https://github.com/companieshouse/overseas-entities-web/pull/916
- https://github.com/companieshouse/overseas-entities-api/pull/277