### PR TITLE
uar-616 use overseas entity id in getOverseasEntityData signature

### DIFF
--- a/src/services/overseas-entities/service.ts
+++ b/src/services/overseas-entities/service.ts
@@ -30,8 +30,8 @@ export default class OverseasEntityService {
         return resource;
     }
 
-    public async getOverseasEntityDetails (companyNumber: string): Promise< Resource<OverseasEntity> | ApiErrorResponse > {
-        const URL = `overseas-entity-details/${companyNumber}`
+    public async getOverseasEntityDetails (overseasEntityId: string): Promise< Resource<OverseasEntityExtraDetails> | ApiErrorResponse > {
+        const URL = `overseas-entity-details/${overseasEntityId}`
         const response: HttpResponse = await this.client.httpGet(URL);
 
         if (response.error) {

--- a/test/services/overseas-entities/overseas.entities.spec.ts
+++ b/test/services/overseas-entities/overseas.entities.spec.ts
@@ -127,7 +127,7 @@ describe("OverseasEntityService GET Tests suite", () => {
 
         const oeService = new OverseasEntityService(mockValues.requestClient);
         const data = (await oeService.getOverseasEntityDetails(
-            mockValues.ENTITY_NUMBER_MOCK
+            mockValues.OVERSEAS_ENTITY_ID
         )) as Resource<OverseasEntityExtraDetails>;
 
         expect(data.httpStatusCode).to.equal(200);
@@ -139,7 +139,7 @@ describe("OverseasEntityService GET Tests suite", () => {
 
         const oeService = new OverseasEntityService(mockValues.requestClient);
         const data = await oeService.getOverseasEntityDetails(
-            mockValues.ENTITY_NUMBER_MOCK
+            mockValues.OVERSEAS_ENTITY_ID
         ) as ApiErrorResponse;
 
         expect(data.httpStatusCode).to.equal(400);


### PR DESCRIPTION
JIRA https://companieshouse.atlassian.net/browse/UAR-616

change getOverseasEntityData signature to take overseas_entity_id instead of oe number 