### PR TITLE
uar-998 add middleName to PSC nameElements

### DIFF
--- a/src/services/company-psc/types.ts
+++ b/src/services/company-psc/types.ts
@@ -46,7 +46,9 @@ export interface DateOfBirthResource {
 };
 
 export interface NameElementsResource {
+  title?: string;
   forename?: string;
+  other_forenames?: string;
   middle_name?: string;
   surname: string;
 };
@@ -115,7 +117,9 @@ export interface DateOfBirth {
 };
 
 export interface NameElements {
+  title?: string;
   forename?: string;
+  otherForenames?: string;
   middleName?: string;
   surname: string;
 };

--- a/src/services/company-psc/types.ts
+++ b/src/services/company-psc/types.ts
@@ -47,6 +47,7 @@ export interface DateOfBirthResource {
 
 export interface NameElementsResource {
   forename?: string;
+  middle_name?: string;
   surname: string;
 };
 
@@ -115,6 +116,7 @@ export interface DateOfBirth {
 
 export interface NameElements {
   forename?: string;
+  middleName?: string;
   surname: string;
 };
 

--- a/test/services/company-psc/service.spec.ts
+++ b/test/services/company-psc/service.spec.ts
@@ -57,6 +57,7 @@ describe("company-psc", () => {
                     etag: "fe416d8a3e09c93eb961ad89b0c606982c3c01e1",
                     name_elements: {
                         forename: "James",
+                        middle_name: "Sirius",
                         surname: "Potter"
                     },
                     nationality: "British",
@@ -125,5 +126,9 @@ describe("company-psc", () => {
         expect(data.resource?.items[0].identification?.legalForm).to.equal(mockResponseBody.items[0].identification?.legal_form);
         expect(data.resource?.items[0].identification?.placeRegistered).to.equal(mockResponseBody.items[0].identification?.place_registered);
         expect(data.resource?.items[0].identification?.registrationNumber).to.equal(mockResponseBody.items[0].identification?.registration_number)
+
+        expect(data.resource?.items[0].nameElements.forename).to.equal(mockResponseBody.items[0].name_elements.forename);
+        expect(data.resource?.items[0].nameElements.middleName).to.equal(mockResponseBody.items[0].name_elements.middle_name);
+        expect(data.resource?.items[0].nameElements.surname).to.equal(mockResponseBody.items[0].name_elements.surname);
     });
 });

--- a/test/services/company-psc/service.spec.ts
+++ b/test/services/company-psc/service.spec.ts
@@ -56,7 +56,9 @@ describe("company-psc", () => {
                     },
                     etag: "fe416d8a3e09c93eb961ad89b0c606982c3c01e1",
                     name_elements: {
+                        title: "Dr",
                         forename: "James",
+                        other_forenames: "young wizard",
                         middle_name: "Sirius",
                         surname: "Potter"
                     },
@@ -127,7 +129,9 @@ describe("company-psc", () => {
         expect(data.resource?.items[0].identification?.placeRegistered).to.equal(mockResponseBody.items[0].identification?.place_registered);
         expect(data.resource?.items[0].identification?.registrationNumber).to.equal(mockResponseBody.items[0].identification?.registration_number)
 
+        expect(data.resource?.items[0].nameElements.title).to.equal(mockResponseBody.items[0].name_elements.title);
         expect(data.resource?.items[0].nameElements.forename).to.equal(mockResponseBody.items[0].name_elements.forename);
+        expect(data.resource?.items[0].nameElements.otherForenames).to.equal(mockResponseBody.items[0].name_elements.other_forenames);
         expect(data.resource?.items[0].nameElements.middleName).to.equal(mockResponseBody.items[0].name_elements.middle_name);
         expect(data.resource?.items[0].nameElements.surname).to.equal(mockResponseBody.items[0].name_elements.surname);
     });


### PR DESCRIPTION
JIRA 

https://companieshouse.atlassian.net/browse/UAR-998

Middle name is defined for PSCs but not included in the Typescript types.

Example from api:
  nameElements: { forename: 'Dr', middleName: 'Lane', surname: 'Foster' }

The CHS dev documentation has: title and fore_names (and no middlename)

The Java API SDK has all of:

title
forename
otherFornames
middleName
surname

aligning with Java API SDK to add all these.