### PR TITLE
CC-605: Do not drop additional headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "eslint-plugin-promise": "6.0.0",
         "eslint-plugin-standard": "5.0.0",
         "mocha": "^9.2.0",
+        "nock": "^13.3.2",
         "sinon": "^9.2.4",
         "sinon-chai": "~3.5.0",
         "sonarqube-scanner": "^2.8.1",
@@ -405,21 +406,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.54.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.54.1.tgz",
@@ -531,21 +517,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.54.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.54.1.tgz",
@@ -595,21 +566,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
       "engines": {
         "node": ">=10"
       }
@@ -1928,6 +1884,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/eslint-plugin-node/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/eslint-plugin-promise": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
@@ -2018,21 +1983,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint/node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
       "engines": {
         "node": ">=10"
       }
@@ -2924,6 +2874,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "node_modules/json5": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
@@ -2993,6 +2949,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -3353,6 +3315,21 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node_modules/nock": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.2.tgz",
+      "integrity": "sha512-CwbljitiWJhF1gL83NbanhoKs1l23TDlRioNraPTZrzZIEooPemrHRj5m0FZCPkB1ecdYCSWWGcHysJgX/ngnQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.21",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
     "node_modules/node-downloader-helper": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/node-downloader-helper/-/node-downloader-helper-2.1.6.tgz",
@@ -3375,6 +3352,15 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/normalize-path": {
@@ -3841,6 +3827,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/punycode": {
@@ -5385,7 +5380,7 @@
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
         "regexpp": "^3.2.0",
-        "semver": "7.5.2",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "dependencies": {
@@ -5394,14 +5389,6 @@
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
           "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
           "dev": true
-        },
-        "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
@@ -5456,18 +5443,8 @@
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "7.5.2",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@typescript-eslint/utils": {
@@ -5483,7 +5460,7 @@
         "@typescript-eslint/typescript-estree": "5.54.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
-        "semver": "7.5.2"
+        "semver": "^7.3.7"
       },
       "dependencies": {
         "eslint-utils": {
@@ -5500,14 +5477,6 @@
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
           "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
           "dev": true
-        },
-        "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
@@ -6317,7 +6286,7 @@
         "optionator": "^0.9.1",
         "progress": "^2.0.0",
         "regexpp": "^3.1.0",
-        "semver": "7.5.2",
+        "semver": "^7.2.1",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
         "table": "^6.0.9",
@@ -6336,14 +6305,6 @@
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
           "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
           "dev": true
-        },
-        "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
@@ -6530,7 +6491,7 @@
         "ignore": "^5.1.1",
         "minimatch": "^3.0.4",
         "resolve": "^1.10.1",
-        "semver": "7.5.2"
+        "semver": "^6.1.0"
       },
       "dependencies": {
         "ignore": {
@@ -6547,6 +6508,12 @@
           "requires": {
             "path-parse": "^1.0.6"
           }
+        },
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
         }
       }
     },
@@ -7225,6 +7192,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "json5": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
@@ -7278,6 +7251,12 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -7551,6 +7530,18 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "nock": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.2.tgz",
+      "integrity": "sha512-CwbljitiWJhF1gL83NbanhoKs1l23TDlRioNraPTZrzZIEooPemrHRj5m0FZCPkB1ecdYCSWWGcHysJgX/ngnQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.21",
+        "propagate": "^2.0.0"
+      }
+    },
     "node-downloader-helper": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/node-downloader-helper/-/node-downloader-helper-2.1.6.tgz",
@@ -7565,8 +7556,16 @@
       "requires": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
-        "semver": "7.5.2",
+        "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -7917,6 +7916,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
     "punycode": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-promise": "6.0.0",
     "eslint-plugin-standard": "5.0.0",
     "mocha": "^9.2.0",
+    "nock": "^13.3.2",
     "sinon": "^9.2.4",
     "sinon-chai": "~3.5.0",
     "sonarqube-scanner": "^2.8.1",

--- a/src/http/request-client.ts
+++ b/src/http/request-client.ts
@@ -31,9 +31,8 @@ export default class RequestClient extends AbstractClient {
             const options: AxiosRequestConfig = {
                 method: additionalOptions.method,
                 headers: {
-                    authorization: this.headers.Authorization,
-                    accept: "application/json",
-                    "content-type": "application/json"
+                    ...this.headers,
+                    ...additionalOptions.headers
                 },
                 url: this.formatUrl(this.options.baseUrl, additionalOptions.url),
                 responseType: "json",

--- a/src/http/request-client.ts
+++ b/src/http/request-client.ts
@@ -27,20 +27,22 @@ export default class RequestClient extends AbstractClient {
     }
 
     private async request (additionalOptions: AdditionalOptions): Promise<HttpResponse> {
+        const headers = {
+            ...this.headers,
+            ...additionalOptions.headers
+        }
         // Default values for these headers if not provided in additional headers.
-        const accept = (additionalOptions.headers && additionalOptions.headers.Accept) || "application/json";
-        const contentType =
-            (additionalOptions.headers && additionalOptions.headers["Content-Type"]) || "application/json";
+        if (!headers.accept && !headers.Accept) {
+            headers.accept = "application/json";
+        }
+        if (!headers["Content-Type"] && !headers["content-type"]) {
+            headers["content-type"] = "application/json";
+        }
 
         try {
             const options: AxiosRequestConfig = {
                 method: additionalOptions.method,
-                headers: {
-                    ...this.headers,
-                    ...additionalOptions.headers,
-                    Accept: accept,
-                    "Content-Type": contentType
-                },
+                headers: headers,
                 url: this.formatUrl(this.options.baseUrl, additionalOptions.url),
                 responseType: "json",
                 validateStatus: status => {

--- a/src/http/request-client.ts
+++ b/src/http/request-client.ts
@@ -1,5 +1,5 @@
 import { AbstractClient, HttpResponse, AdditionalOptions, Headers } from "./http-client";
-import axios, { AxiosRequestConfig, AxiosResponse, AxiosError } from "axios";
+import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 
 /**
  * RequestClient is an implementation of our http client using the request
@@ -27,12 +27,19 @@ export default class RequestClient extends AbstractClient {
     }
 
     private async request (additionalOptions: AdditionalOptions): Promise<HttpResponse> {
+        // Default values for these headers if not provided in additional headers.
+        const accept = (additionalOptions.headers && additionalOptions.headers.Accept) || "application/json";
+        const contentType =
+            (additionalOptions.headers && additionalOptions.headers["Content-Type"]) || "application/json";
+
         try {
             const options: AxiosRequestConfig = {
                 method: additionalOptions.method,
                 headers: {
                     ...this.headers,
-                    ...additionalOptions.headers
+                    ...additionalOptions.headers,
+                    Accept: accept,
+                    "Content-Type": contentType
                 },
                 url: this.formatUrl(this.options.baseUrl, additionalOptions.url),
                 responseType: "json",

--- a/test/http/request-client.spec.ts
+++ b/test/http/request-client.spec.ts
@@ -149,6 +149,31 @@ describe("request-client", () => {
         scope.done();
     });
 
+    it("propagates additional headers provided by client, regardless of header name case", async () => {
+        // Given
+        const client = new RequestClient({ oauthToken: "123", baseUrl: "http://localhost" });
+        const scope = nock(/.*/)
+            .patch("/orderable/certificates/CHS001")
+            .matchHeader("Authorization", "Bearer 123")
+            .matchHeader("Accept", "application/merge-patch+json")
+            .matchHeader("Content-Type", "application/merge-patch+json")
+            .matchHeader("Example", "Example value")
+            .reply(200);
+
+        // When
+        const resp = await client.httpPatch("/orderable/certificates/CHS001",
+            { data: "bar" },
+            {
+                "content-type": "application/merge-patch+json",
+                accept: "application/merge-patch+json",
+                Example: "Example value"
+            });
+
+        // Then
+        expect(resp.status).to.equal(200);
+        scope.done();
+    });
+
     it("sets default headers correctly where not provided in additional headers", async () => {
         // Given
         const client = new RequestClient({ oauthToken: "123", baseUrl: "http://localhost" });

--- a/test/http/request-client.spec.ts
+++ b/test/http/request-client.spec.ts
@@ -1,9 +1,8 @@
 import chai from "chai";
 import sinon from "sinon";
-import chaiAsPromised from "chai-as-promised";
-import chaiHttp from "chai-http";
 
-import { RequestClient, HttpResponse } from "../../src/http";
+import { RequestClient } from "../../src/http";
+import nock = require("nock");
 const expect = chai.expect;
 
 describe("request-client", () => {
@@ -123,6 +122,28 @@ describe("request-client", () => {
         expect(resp.error).to.be.undefined;
         expect(resp.body).to.deep.equal(body);
         expect(resp.status).to.equal(statusCode);
+    });
+
+    it("propagates additional header required for PATCH merge", async () => {
+        // Given
+        const client = new RequestClient({ oauthToken: "123", baseUrl: "http://localhost" });
+        const requiredMergePatchHeader = {
+            name: "Content-Type",
+            value: "application/merge-patch+json"
+        }
+        const scope = nock(/.*/)
+            .patch("/orderable/certificates/CHS001")
+            .matchHeader(requiredMergePatchHeader.name, requiredMergePatchHeader.value)
+            .reply(200);
+
+        // When
+        const resp = await client.httpPatch("/orderable/certificates/CHS001",
+            { data: "bar" },
+            { "Content-Type": "application/merge-patch+json" });
+
+        // Then
+        scope.done();
+        expect(resp.status).to.equal(200);
     });
 
     it("returns an error response when HTTP PUT request fails", async () => {

--- a/test/services/certificates/service.spec.ts
+++ b/test/services/certificates/service.spec.ts
@@ -804,8 +804,8 @@ describe("update a certificate PATCH", () => {
             Success<ApiResponse<CertificateItem>, ApiErrorResponse>;
 
         // Then
-        scope.done();
         expect(data.value.httpStatusCode).to.equal(200);
+        scope.done();
     });
 });
 

--- a/test/services/certificates/service.spec.ts
+++ b/test/services/certificates/service.spec.ts
@@ -9,9 +9,10 @@ import {
     CertificateItemPatchRequest,
     CertificateItemPostRequest,
     CertificateItemResource
-} from "../../../src/services/order/certificates/types";
+} from "../../../src/services/order/certificates";
 import { ApiErrorResponse, ApiResponse } from "../../../src/services/resource";
 import { Failure, Success } from "../../../src/services/result";
+import nock = require("nock");
 
 const expect = chai.expect;
 
@@ -778,6 +779,33 @@ describe("update a certificate PATCH", () => {
         expect(io.liquidatorsDetails).to.be.undefined;
         expect(io.companyStatus).to.be.undefined;
         expect(io.administratorsDetails).to.be.undefined;
+    });
+
+    it("sets additional header required for PATCH merge", async () => {
+        // Given
+        const requestClient = new RequestClient({
+            baseUrl: "http://localhost",
+            oauthToken: "TOKEN-NOT-USED"
+        });
+        // patchCertificate sets this header, so we expect to see it sent in outgoing HTTP request.
+        // Effectively testing both CertificateService and RequestClient.
+        const expectedMergePatchHeader = {
+            name: "Content-Type",
+            value: "application/merge-patch+json"
+        }
+        const scope = nock(/.*/)
+            .patch("/orderable/certificates/CHS001")
+            .matchHeader(expectedMergePatchHeader.name, expectedMergePatchHeader.value)
+            .reply(200);
+        const certificate: CertificateService = new CertificateService(requestClient);
+
+        // When
+        const data = await certificate.patchCertificate(mockRequestBody, certificateId) as
+            Success<ApiResponse<CertificateItem>, ApiErrorResponse>;
+
+        // Then
+        scope.done();
+        expect(data.value.httpStatusCode).to.equal(200);
     });
 });
 


### PR DESCRIPTION
* This work undoes a change made back in April that was recently found to result in the SDK not propagating additional headers provided to its outgoing HTTP requests, as described in [the bug](https://companieshouse.atlassian.net/browse/CC-605).
* It also provides a couple of automated tests that hopefully should catch such issues should they arise again.
* The substantive change was tested with the `certificates.orders.web.ch.gov.uk` node application [manually in Tilt](https://companieshouse.atlassian.net/browse/CC-605?focusedCommentId=220161) earlier today.  