### PR TITLE
DACT-634-Move-Post-Request

### DIFF
--- a/src/services/officer-filing/types.ts
+++ b/src/services/officer-filing/types.ts
@@ -76,7 +76,7 @@ export interface ValidationStatusResponseResource {
  * CompanyOfficers is the interface used within this SDK.
  */
 export interface OfficerCard {
-    removeUrl: string;
+    appointmentId: string;
     officer: CompanyOfficer;
 }
 


### PR DESCRIPTION
Context

Currently we send the Post from the load of the date removal screen. Ideally we would run this from the click of the remove a director link on the list of active directors screen.

However, we have found a technical constraint for TM01 that is caused by the link to remove a director on the current directors' page. A button would be the preferred way for handling posts going forward.

Why do we need to resolve this issue asap?

The issue is that Links cannot be used to run a POST request without using javascript to do the submit of the post - Buttons on pages can be used to run a POST request.

We need to run a POST request as we are setting up the filing for that individual director when you click on the remove director link on the current directors' page.

We currently do a POST on the next page (Date of remove), but if you refresh that page, it then runs a new post, which will break the load of data on the page when you click back.