### PR TITLE
Add null check to penalty list items

### DIFF
--- a/src/services/lfp/service.ts
+++ b/src/services/lfp/service.ts
@@ -25,7 +25,7 @@ export default class {
             itemsPerPage: resp.body.items_per_page,
             startIndex: resp.body.start_index,
             totalResults: resp.body.total_results,
-            items: resp.body.items.map((i) => ({
+            items: resp.body.items ? resp.body.items.map((i) => ({
                 id: i.id,
                 etag: i.etag,
                 kind: i.kind,
@@ -37,7 +37,7 @@ export default class {
                 originalAmount: i.original_amount,
                 outstandingAmount: i.outstanding,
                 type: i.type
-            }))
+            })) : []
         };
 
         return resource;

--- a/test/services/lfp/service.spec.ts
+++ b/test/services/lfp/service.spec.ts
@@ -35,6 +35,32 @@ describe("lfp", () => {
         expect(data.resource).to.be.undefined
     });
 
+    it("maps the penalty data correctly if there are no penalties", async () => {
+        const mockResponseBody = ({
+            etag: "string",
+            items_per_page: 0,
+            start_index: 0,
+            total_results: 0,
+            items: null // lfp-pay-api returns null if there are no penalties
+        });
+
+        const mockGetResponse = {
+            status: 200,
+            body: mockResponseBody
+        };
+
+        const mockRequest = sinon.stub(requestClient, "httpGet").resolves(mockGetResponse);
+        const companyProfile : LateFilingPenaltyService = new LateFilingPenaltyService(requestClient);
+        const data = await companyProfile.getPenalties("NUMBER-NOT-IMPORTANT");
+
+        expect(data.httpStatusCode).to.equal(200);
+        expect(data.resource.etag).to.equal(mockResponseBody.etag);
+        expect(data.resource.itemsPerPage).to.equal(mockResponseBody.items_per_page);
+        expect(data.resource.startIndex).to.equal(mockResponseBody.start_index);
+        expect(data.resource.totalResults).to.equal(mockResponseBody.total_results);
+        expect(data.resource.items.length).to.eql(0);
+    });
+
     it("maps the penalty data items correctly", async () => {
         const mockResponseBody = ({
             etag: "string",


### PR DESCRIPTION
This pr changes the penalties sdk so that when the lfp-pay-api returns null for company penalty items, the service takes that as there being no penalties and a blank array is used. This is to fix an issue seen in the lfp-appeals-frontend when a company with no penalities is used.