### PR TITLE
Chore/CC-142: Add comment annotation to discourage direct use of method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@ import { RequestClient, HttpClientOptions, IHttpClient } from "./http";
 import Resource from "./services/resource";
 
 /**
- * 
- * @warning - Please do not use this method to create API clients directly. Use the sdk-manager-node instead
+ *
+ * @warning - Please do not use this method to create API clients directly. Use the sdk-manager-node instead (which in turn calls this method)
  *
  * Creates a new API Client.
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { RequestClient, HttpClientOptions, IHttpClient } from "./http";
 import Resource from "./services/resource";
 
 /**
+ * 
  * @warning - Please do not use this method to create API clients directly. Use the sdk-manager-node instead
  *
  * Creates a new API Client.

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { RequestClient, HttpClientOptions, IHttpClient } from "./http";
 import Resource from "./services/resource";
 
 /**
+ * @warning - Please do not use this method to create API clients directly. Use the sdk-manager-node instead
+ *
  * Creates a new API Client.
  *
  * @param apiKey the api key to use for authentication


### PR DESCRIPTION
Adds comment annotation discouraging direct use of the `createApiClient` method in favour of `sdk-manager-node`