### PR TITLE
confirmation-statement-web service call changes reqd for confirm registered email address

### DIFF
--- a/src/services/confirmation-statement/service.ts
+++ b/src/services/confirmation-statement/service.ts
@@ -19,6 +19,8 @@ import {
     PersonOfSignificantControlResource,
     RegisteredOfficeAddressData,
     RegisteredOfficeAddressDataResource,
+    RegisteredEmailAddressData,
+    RegisteredEmailAddressDataResource,
     SicCode,
     SicCodeData,
     SicCodeDataResource,
@@ -299,6 +301,7 @@ export default class {
             ...(dataResource.statement_of_capital_data && { statementOfCapitalData: this.mapToStatementOfCapitalData(dataResource.statement_of_capital_data) }),
             ...(dataResource.sic_code_data && { sicCodeData: this.mapToSicCodeData(dataResource.sic_code_data) }),
             ...(dataResource.registered_office_address_data && { registeredOfficeAddressData: this.mapToRegisteredOfficeAddressData(dataResource.registered_office_address_data) }),
+            ...(dataResource.registered_email_address_data && { registeredEmailAddressData: this.mapToRegisteredEmailAddressData(dataResource.registered_email_address_data) }),
             ...(dataResource.active_officer_details_data && { activeOfficerDetailsData: this.mapToActiveOfficerDetailsData(dataResource.active_officer_details_data) }),
             ...(dataResource.shareholder_data && { shareholderData: this.mapToShareholderData(dataResource.shareholder_data) }),
             ...(dataResource.register_locations_data && { registerLocationsData: this.mapToRegisterLocationsData(dataResource.register_locations_data) }),
@@ -313,6 +316,7 @@ export default class {
             ...(data.statementOfCapitalData && { statement_of_capital_data: this.mapToStatementOfCapitalDataResource(data.statementOfCapitalData) }),
             ...(data.sicCodeData && { sic_code_data: this.mapToSicCodeDataResource(data.sicCodeData) }),
             ...(data.registeredOfficeAddressData && { registered_office_address_data: this.mapToRegisteredOfficeAddressDataResource(data.registeredOfficeAddressData) }),
+            ...(data.registeredEmailAddressData && { registered_email_address_data: this.mapToRegisteredEmailAddressDataResource(data.registeredEmailAddressData) }),
             ...(data.activeOfficerDetailsData && { active_officer_details_data: this.mapToActiveOfficerDetailsDataResource(data.activeOfficerDetailsData) }),
             ...(data.shareholderData && { shareholder_data: this.mapToShareholderDataResource(data.shareholderData) }),
             ...(data.registerLocationsData && { register_locations_data: this.mapToRegisterLocationsDataResource(data.registerLocationsData) }),
@@ -564,6 +568,18 @@ export default class {
     private mapToRegisteredOfficeAddressData (registeredOfficeAddressResource: RegisteredOfficeAddressDataResource): RegisteredOfficeAddressData {
         return {
             sectionStatus: registeredOfficeAddressResource.section_status
+        }
+    }
+
+    private mapToRegisteredEmailAddressDataResource (registeredEmailAddress: RegisteredEmailAddressData): RegisteredEmailAddressDataResource {
+        return {
+            section_status: registeredEmailAddress.sectionStatus
+        }
+    }
+
+    private mapToRegisteredEmailAddressData (registeredEmailAddressResource: RegisteredEmailAddressDataResource): RegisteredEmailAddressData {
+        return {
+            sectionStatus: registeredEmailAddressResource.section_status
         }
     }
 

--- a/src/services/confirmation-statement/types.ts
+++ b/src/services/confirmation-statement/types.ts
@@ -20,6 +20,7 @@ export interface ConfirmationStatementSubmissionDataResource {
     persons_significant_control_data?: PersonsOfSignificantControlDataResource,
     register_locations_data?: RegisterLocationsDataResource,
     registered_office_address_data?: RegisteredOfficeAddressDataResource,
+    registered_email_address_data?: RegisteredEmailAddressDataResource,
     shareholder_data?: ShareholderDataResource,
     sic_code_data?: SicCodeDataResource,
     statement_of_capital_data?: StatementOfCapitalDataResource,
@@ -31,6 +32,7 @@ export interface ConfirmationStatementSubmissionData {
     confirmationStatementMadeUpToDate: string,
     personsSignificantControlData?: PersonsOfSignificantControlData,
     registeredOfficeAddressData?: RegisteredOfficeAddressData,
+    registeredEmailAddressData?: RegisteredEmailAddressData,
     registerLocationsData?: RegisterLocationsData,
     shareholderData?: ShareholderData,
     sicCodeData?: SicCodeData,
@@ -76,6 +78,12 @@ export interface RegisteredOfficeAddressDataResource extends ConfirmationStateme
 export interface RegisteredOfficeAddressData extends ConfirmationStatementSubmissionSection {
 }
 
+export interface RegisteredEmailAddressDataResource extends ConfirmationStatementSubmissionSectionResource {
+}
+
+export interface RegisteredEmailAddressData extends ConfirmationStatementSubmissionSection {
+}
+
 export interface ActiveOfficerDetailsDataResource extends ConfirmationStatementSubmissionSectionResource {
 }
 
@@ -97,7 +105,8 @@ export interface RegisterLocationsData extends ConfirmationStatementSubmissionSe
 export enum SectionStatus {
     CONFIRMED = "CONFIRMED",
     NOT_CONFIRMED = "NOT_CONFIRMED",
-    RECENT_FILING = "RECENT_FILING"
+    RECENT_FILING = "RECENT_FILING",
+    INITIAL_FILING = "INITIAL_FILING"
 }
 
 export enum EligibilityStatusCode {

--- a/test/services/confirmation-statement/confirmation.statement.mock.ts
+++ b/test/services/confirmation-statement/confirmation.statement.mock.ts
@@ -60,6 +60,7 @@ export const mockConfirmationStatementSubmission: ConfirmationStatementSubmissio
             personsOfSignificantControl: []
         },
         registeredOfficeAddressData: { sectionStatus: SectionStatus.CONFIRMED },
+        registeredEmailAddressData: { sectionStatus: SectionStatus.INITIAL_FILING },
         statementOfCapitalData: {
             sectionStatus: null,
             statementOfCapital: {
@@ -261,6 +262,7 @@ export const mockConfirmationStatementSubmissionResource: ConfirmationStatementS
         },
         active_officer_details_data: { section_status: SectionStatus.CONFIRMED },
         registered_office_address_data: { section_status: SectionStatus.CONFIRMED },
+        registered_email_address_data: { section_status: SectionStatus.INITIAL_FILING },
         register_locations_data: { section_status: SectionStatus.CONFIRMED },
         statement_of_capital_data: {
             section_status: SectionStatus.CONFIRMED,

--- a/test/services/confirmation-statement/confirmation.statement.spec.ts
+++ b/test/services/confirmation-statement/confirmation.statement.spec.ts
@@ -157,6 +157,7 @@ describe("Update confirmation statement POST", () => {
         expect(updatedConfirmationStatement.data.sicCodeData.sectionStatus).to.equal(mockSubmission.data.sic_code_data.section_status);
         expect(updatedConfirmationStatement.data.sicCodeData.sicCode.code).to.equal(mockSubmission.data.sic_code_data.sic_code.code);
         expect(updatedConfirmationStatement.data.registeredOfficeAddressData.sectionStatus).to.equal(mockSubmission.data.registered_office_address_data.section_status);
+        expect(updatedConfirmationStatement.data.registeredEmailAddressData.sectionStatus).to.equal(mockSubmission.data.registered_email_address_data.section_status);
         expect(updatedConfirmationStatement.data.activeOfficerDetailsData.sectionStatus).to.equal(mockSubmission.data.active_officer_details_data.section_status);
         expect(updatedConfirmationStatement.data.shareholderData.sectionStatus).to.equal(mockSubmission.data.shareholder_data.section_status);
         expect(updatedConfirmationStatement.data.registerLocationsData.sectionStatus).to.equal(mockSubmission.data.register_locations_data.section_status);


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ECCT-719

New functionality in CHS Confirmation Statement service to confirm the email address for the first time. Cross web service call from confirmation-statement-web service to ConfirmationStatementSubmission and update the section status for registered_email_address_data.
New section status of 'INITIAL_FILING'.