### PR TITLE
dact-1816 remove getCurrentOrFututureDissolved from officer filling

### DIFF
--- a/src/services/officer-filing/service.ts
+++ b/src/services/officer-filing/service.ts
@@ -46,17 +46,6 @@ export default class {
         return this.getCompanyOfficerDetails(url);
     }
 
-    public async getCurrentOrFutureDissolved (companyNumber: String): Promise<Resource<Boolean> | ApiErrorResponse> {
-        const url = `/officer-filing/company/${companyNumber}/eligibility-check/past-future-dissolved`;
-        const resp: HttpResponse = await this.client.httpGet(url);
-
-        if (resp.status >= 400) {
-            return { httpStatusCode: resp.status, errors: [resp.error] };
-        }
-
-        return { httpStatusCode: resp.status, resource: resp.body as Boolean };
-    }
-
     private async getValidationStatusResponse (url: string): Promise<Resource<ValidationStatusResponse> | ApiErrorResponse> {
         const resp: HttpResponse = await this.client.httpGet(url);
 

--- a/test/services/officer-filing/officer.filing.spec.ts
+++ b/test/services/officer-filing/officer.filing.spec.ts
@@ -74,35 +74,6 @@ describe("List TM01 check your answers details GET", () => {
     });
 });
 
-describe("Current or future dissolved GET", () => {
-    it("should return Boolean value", async () => {
-        sinon.stub(mockValues.requestClient, "httpGet").resolves(mockValues.mockGetCurrentOrFutureDissolved[200]);
-        const ofService: OfficerFilingService = new OfficerFilingService(mockValues.requestClient);
-        const data: Resource<Boolean> = await ofService.getCurrentOrFutureDissolved(COMPANY_NUMBER) as Resource<Boolean>;
-
-        expect(data.httpStatusCode).to.equal(200);
-        expect(data.resource).to.equal(true);
-    });
-
-    it("should return Boolean value of false", async () => {
-        sinon.stub(mockValues.requestClient, "httpGet").resolves(mockValues.mockGetCurrentOrFutureDissolvedReturnsFalse[200]);
-        const ofService: OfficerFilingService = new OfficerFilingService(mockValues.requestClient);
-        const data: Resource<Boolean> = await ofService.getCurrentOrFutureDissolved(COMPANY_NUMBER) as Resource<Boolean>;
-
-        expect(data.httpStatusCode).to.equal(200);
-        expect(data.resource).to.equal(false);
-    });
-
-    it("should return error 500 - Internal server error", async () => {
-        sinon.stub(mockValues.requestClient, "httpGet").resolves(mockValues.mockGetCurrentOrFutureDissolved[500]);
-        const ofService: OfficerFilingService = new OfficerFilingService(mockValues.requestClient);
-        const data: ApiErrorResponse = await ofService.getCurrentOrFutureDissolved(COMPANY_NUMBER);
-
-        expect(data.httpStatusCode).to.equal(500);
-        expect(data.errors?.[0]).to.equal("Internal server error");
-    });
-});
-
 describe("Validation Status Response GET", () => {
     it("should return list of error/s and validation status", async () => {
         sinon.stub(mockValues.requestClient, "httpGet").resolves(mockValues.mockGetValidationStatusResponse[200]);


### PR DESCRIPTION
JIRA https://companieshouse.atlassian.net/jira/software/c/projects/DACT/boards/492?selectedIssue=DACT-1816
Remove getCurrentOrFutureDissolved from SDK as web can use companyProfile directly instead.