### PR TITLE
dact-2515 test for status to skip mapping response

### DIFF
--- a/src/services/officer-filing/service.ts
+++ b/src/services/officer-filing/service.ts
@@ -119,6 +119,7 @@ export default class {
             httpStatusCode: resp.status
         };
         const body = resp.body as FilingResponseDto;
+
         this.populateResource(resource, body);
         return resource;
     }

--- a/src/services/officer-filing/service.ts
+++ b/src/services/officer-filing/service.ts
@@ -89,11 +89,9 @@ export default class {
         const officerFilingResource: OfficerFilingDto = this.mapToDto(officerFiling);
 
         const resp = await this.client.httpPost(url, officerFilingResource);
-        if (resp.error) {
-            return {
-                httpStatusCode: resp.status,
-                errors: [resp.error]
-            };
+
+        if (resp.status >= 400) {
+            return { httpStatusCode: resp.status, errors: [resp.error] };
         }
 
         const resource: Resource<FilingResponse> = {
@@ -112,11 +110,9 @@ export default class {
         const officerFilingResource: OfficerFilingDto = this.mapToDto(officerFiling);
 
         const resp = await this.client.httpPatch(url, officerFilingResource);
-        if (resp.error) {
-            return {
-                httpStatusCode: resp.status,
-                errors: [resp.error]
-            };
+
+        if (resp.status >= 400) {
+            return { httpStatusCode: resp.status, errors: [resp.error] };
         }
 
         const resource: Resource<FilingResponse> = {

--- a/test/services/officer-filing/officer.filing.mock.ts
+++ b/test/services/officer-filing/officer.filing.mock.ts
@@ -129,6 +129,7 @@ export const mockPatchOfficerFiling = {
     200: {
         status: 200,
         body: {
+            id: "123",
             data: {
                 description: "Appoint a new Director"
             }
@@ -142,6 +143,7 @@ export const mockPostOfficerFiling = {
     200: {
         status: 200,
         body: {
+            id: "567",
             data: {
                 description: "Update a Director"
             }

--- a/test/services/officer-filing/officer.filing.mock.ts
+++ b/test/services/officer-filing/officer.filing.mock.ts
@@ -125,6 +125,32 @@ export const mockGetOfficerFiling = {
     500: { status: 500, error: "Internal server error" }
 };
 
+export const mockPatchOfficerFiling = {
+    200: {
+        status: 200,
+        body: {
+            data: {
+                description: "Appoint a new Director"
+            }
+        }
+    },
+    404: { status: 404, error: "Officer filing not found" },
+    500: { status: 500, error: "Internal server error" }
+};
+
+export const mockPostOfficerFiling = {
+    200: {
+        status: 200,
+        body: {
+            data: {
+                description: "Update a Director"
+            }
+        }
+    },
+    404: { status: 404, error: "Officer filing not found" },
+    500: { status: 500, error: "Internal server error" }
+};
+
 export const mockGetListActiveDirectorsDetails = {
     200: { status: 200, body: mockListActiveDirectorDetails },
     404: { status: 404, error: "No active directors details were found" },

--- a/test/services/officer-filing/officer.filing.spec.ts
+++ b/test/services/officer-filing/officer.filing.spec.ts
@@ -143,6 +143,7 @@ describe("Officer Filing POST", () => {
         const data: Resource<FilingResponse> = await ofService.postOfficerFiling(TRANSACTION_ID, {}) as Resource<FilingResponse>;
 
         expect(data.httpStatusCode).to.equal(200);
+        expect(data.resource?.id).to.equal("567");
         expect(data.resource?.data?.description).to.equal("Update a Director");
     });
 
@@ -172,6 +173,7 @@ describe("Officer Filing PATCH", () => {
         const data: Resource<FilingResponse> = await ofService.patchOfficerFiling(TRANSACTION_ID, SUBMISSION_ID, {}) as Resource<FilingResponse>;
 
         expect(data.httpStatusCode).to.equal(200);
+        expect(data.resource?.id).to.equal("123");
         expect(data.resource?.data?.description).to.equal("Appoint a new Director");
     });
 

--- a/test/services/officer-filing/officer.filing.spec.ts
+++ b/test/services/officer-filing/officer.filing.spec.ts
@@ -1,5 +1,5 @@
 import {
-    CompanyOfficer, OfficerFiling, OfficerFilingService, ValidationStatusResponse
+    CompanyOfficer, FilingResponse, OfficerFiling, OfficerFilingService, ValidationStatusResponse
 } from "../../../src/services/officer-filing";
 import * as mockValues from "./officer.filing.mock";
 import { expect } from "chai";
@@ -130,6 +130,64 @@ describe("Officer Filing GET", () => {
         sinon.stub(mockValues.requestClient, "httpGet").resolves(mockValues.mockGetOfficerFiling[500]);
         const ofService: OfficerFilingService = new OfficerFilingService(mockValues.requestClient);
         const data: ApiErrorResponse = await ofService.getOfficerFiling(TRANSACTION_ID, SUBMISSION_ID);
+
+        expect(data.httpStatusCode).to.equal(500);
+        expect(data.errors?.[0]).to.equal("Internal server error");
+    });
+});
+
+describe("Officer Filing POST", () => {
+    it("should return an officer filing", async () => {
+        sinon.stub(mockValues.requestClient, "httpPost").resolves(mockValues.mockPostOfficerFiling[200]);
+        const ofService: OfficerFilingService = new OfficerFilingService(mockValues.requestClient);
+        const data: Resource<FilingResponse> = await ofService.postOfficerFiling(TRANSACTION_ID, {}) as Resource<FilingResponse>;
+
+        expect(data.httpStatusCode).to.equal(200);
+        expect(data.resource?.data?.description).to.equal("Update a Director");
+    });
+
+    it("should return error 404 - Not found", async () => {
+        sinon.stub(mockValues.requestClient, "httpPatch").resolves(mockValues.mockPatchOfficerFiling[404]);
+        const ofService: OfficerFilingService = new OfficerFilingService(mockValues.requestClient);
+        const data: ApiErrorResponse = await ofService.patchOfficerFiling(TRANSACTION_ID, SUBMISSION_ID, {});
+
+        expect(data.httpStatusCode).to.equal(404);
+        expect(data.errors?.[0]).to.equal("Officer filing not found");
+    });
+
+    it("should return error 500 - Internal server error", async () => {
+        sinon.stub(mockValues.requestClient, "httpPatch").resolves(mockValues.mockPatchOfficerFiling[500]);
+        const ofService: OfficerFilingService = new OfficerFilingService(mockValues.requestClient);
+        const data: ApiErrorResponse = await ofService.patchOfficerFiling(TRANSACTION_ID, SUBMISSION_ID, {});
+
+        expect(data.httpStatusCode).to.equal(500);
+        expect(data.errors?.[0]).to.equal("Internal server error");
+    });
+});
+
+describe("Officer Filing PATCH", () => {
+    it("should return an officer filing", async () => {
+        sinon.stub(mockValues.requestClient, "httpPatch").resolves(mockValues.mockPatchOfficerFiling[200]);
+        const ofService: OfficerFilingService = new OfficerFilingService(mockValues.requestClient);
+        const data: Resource<FilingResponse> = await ofService.patchOfficerFiling(TRANSACTION_ID, SUBMISSION_ID, {}) as Resource<FilingResponse>;
+
+        expect(data.httpStatusCode).to.equal(200);
+        expect(data.resource?.data?.description).to.equal("Appoint a new Director");
+    });
+
+    it("should return error 404 - Not found", async () => {
+        sinon.stub(mockValues.requestClient, "httpPatch").resolves(mockValues.mockPatchOfficerFiling[404]);
+        const ofService: OfficerFilingService = new OfficerFilingService(mockValues.requestClient);
+        const data: ApiErrorResponse = await ofService.patchOfficerFiling(TRANSACTION_ID, SUBMISSION_ID, {});
+
+        expect(data.httpStatusCode).to.equal(404);
+        expect(data.errors?.[0]).to.equal("Officer filing not found");
+    });
+
+    it("should return error 500 - Internal server error", async () => {
+        sinon.stub(mockValues.requestClient, "httpPatch").resolves(mockValues.mockPatchOfficerFiling[500]);
+        const ofService: OfficerFilingService = new OfficerFilingService(mockValues.requestClient);
+        const data: ApiErrorResponse = await ofService.patchOfficerFiling(TRANSACTION_ID, SUBMISSION_ID, {});
 
         expect(data.httpStatusCode).to.equal(500);
         expect(data.errors?.[0]).to.equal("Internal server error");


### PR DESCRIPTION
JIRA https://companieshouse.atlassian.net/browse/DACT-2515
Web logs were showing a null reference failure to map response so added explicit check for status before mapping.
Noticed no tests on POST or PATCH officer filing so added some.