### PR TITLE
Move accounts filing to public sdk

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -32,6 +32,7 @@ import RegisteredEmailAddressService from "./services/registered-email-address/s
 import { ClientType } from "./enums";
 import { PostcodeLookupService } from "./services/postcode-lookup";
 import PscVerificationService from "./services/psc-verification-link/service";
+import { AccountsFilingService } from "./services/accounts-filing";
 
 /**
  * ApiClient is the class that all service objects hang off.
@@ -68,6 +69,7 @@ export default class ApiClient {
   public readonly officerFiling: OfficerFilingService;
   public readonly postCodeLookup: PostcodeLookupService;
   public readonly pscVerificationService: PscVerificationService;
+  public readonly accountsFilingService: AccountsFilingService;
 
   constructor (readonly apiClient: IHttpClient, readonly accountClient: IHttpClient) {
       // services on the api domain using the apiClient
@@ -103,5 +105,6 @@ export default class ApiClient {
       this.registeredEmailAddressService = new RegisteredEmailAddressService(apiClient);
       this.postCodeLookup = new PostcodeLookupService(apiClient);
       this.pscVerificationService = new PscVerificationService(apiClient);
+      this.accountsFilingService = new AccountsFilingService(apiClient);
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,2 +1,6 @@
 export const API_URL = process.env.API_URL || "https://api.companieshouse.gov.uk";
 export const ACCOUNT_URL = process.env.ACCOUNT_URL || "https://account.companieshouse.gov.uk";
+
+// Header used to correlate logs between services.
+// This will be used as the context key for logging.
+export const REQUEST_ID_HEADER = "X-Request-Id";

--- a/src/services/account-validator/types.ts
+++ b/src/services/account-validator/types.ts
@@ -1,0 +1,77 @@
+import { PackageType } from "../accounts-filing/types";
+
+export interface AccountValidatorRequest {
+    fileName: string;
+    id: string;
+    packageType?: PackageType;
+}
+
+export interface Data {
+    balanceSheetDate: string;
+    accountsType: string;
+    companieshouseRegisteredNumber: string;
+}
+
+export interface ErrorMessage {
+    errorMessage: string;
+}
+
+export interface Result {
+    errorMessages: ErrorMessage[];
+    data: Data;
+    validationStatus: ValidationStatus;
+}
+
+export interface AccountValidatorResponse {
+    status: RequestStatus;
+    result: Result;
+    fileId: string;
+    fileName: string;
+}
+
+type RequestStatus = "complete" | "pending" | "error" ;
+type ValidationStatus = "OK" | "FAILED"
+
+export function isAccountValidatorResponse (object: any): object is AccountValidatorResponse {
+    if (typeof object.status !== "string" ||
+        typeof object.fileId !== "string" ||
+        typeof object.fileName !== "string") {
+        return false;
+    }
+
+    if (!["complete", "pending", "error"].includes(object.status)) {
+        return false;
+    }
+
+    if (typeof object.result !== "object" || object.result === null) {
+        return false;
+    }
+
+    const { errorMessages, data, validationStatus } = object.result;
+    if ((errorMessages !== undefined && !Array.isArray(errorMessages)) ||
+        typeof data !== "object" ||
+        typeof validationStatus !== "string") {
+        return false;
+    }
+
+    if (!["OK", "FAILED"].includes(validationStatus)) {
+        return false;
+    }
+
+    if (typeof data.balance_sheet_date !== "string" ||
+       typeof data.accounts_type !== "string" ||
+       typeof data.companieshouse_registered_number !== "string") {
+        return false;
+    }
+
+    for (const errorMessage of errorMessages ?? []) {
+        if (typeof errorMessage !== "object" || errorMessage === null) {
+            return false;
+        }
+        if (typeof errorMessage.errorMessage !== "string") {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/services/accounts-filing/index.ts
+++ b/src/services/accounts-filing/index.ts
@@ -1,0 +1,1 @@
+export { AccountsFilingService } from "./service";

--- a/src/services/accounts-filing/service.ts
+++ b/src/services/accounts-filing/service.ts
@@ -4,6 +4,7 @@ import { isAccountValidatorResponse } from "../../services/account-validator/typ
 import { AccountsFilingValidationRequest, AccountsFileValidationResponse, AccountsFilingCompanyResponse, PackageType, PackageTypeRequest, ConfirmCompanyRequest } from "./types";
 import Mapping from "../../mapping/mapping";
 import { Failure, Result, Success } from "../result";
+import { addReuestIdHeader } from "../../util";
 
 const HTTP_STATUS_OK = 200;
 const HTTP_STATUS_NOT_FOUND = 404;
@@ -33,9 +34,10 @@ export class AccountsFilingService {
      * @param transactionId The transaction Id
      * @returns the company response.
      */
-    public async confirmCompany (companyNumber: string, transactionId: string, confirmCompanyRequest: ConfirmCompanyRequest): Promise<Resource<AccountsFilingCompanyResponse>> {
+    public async confirmCompany (companyNumber: string, transactionId: string, confirmCompanyRequest: ConfirmCompanyRequest, requestId?: string): Promise<Resource<AccountsFilingCompanyResponse>> {
         const url = `/transactions/${transactionId}/accounts-filing/company/${companyNumber}/confirm`;
-        const resp = await this.client.httpPut(url, confirmCompanyRequest);
+        const headers = addReuestIdHeader(requestId);
+        const resp = await this.client.httpPut(url, confirmCompanyRequest, headers);
 
         const resource: Resource<AccountsFilingCompanyResponse> = {
             httpStatusCode: resp.status
@@ -208,7 +210,7 @@ export class AccountsFilingService {
         };
     }
 
-    public async setPackageType (transactionId: string, accountsFilingId: string, packageType: PackageType): Promise<Result<void, Error>> {
+    public async setPackageType (transactionId: string, accountsFilingId: string, packageType: PackageType, requestId?: string): Promise<Result<void, Error>> {
         const url = `/transactions/${transactionId}/accounts-filing/${accountsFilingId}`;
 
         const packageTypeRequest: PackageTypeRequest = {
@@ -216,7 +218,8 @@ export class AccountsFilingService {
         }
 
         const requestBody = Mapping.snakeCaseKeys(packageTypeRequest);
-        const resp = await this.client.httpPut(url, requestBody);
+        const headers = addReuestIdHeader(requestId)
+        const resp = await this.client.httpPut(url, requestBody, headers);
 
         // Needed due to javascripts switch block scoping rules
         let errorMessage = "";

--- a/src/services/accounts-filing/service.ts
+++ b/src/services/accounts-filing/service.ts
@@ -4,7 +4,7 @@ import { isAccountValidatorResponse } from "../../services/account-validator/typ
 import { AccountsFilingValidationRequest, AccountsFileValidationResponse, AccountsFilingCompanyResponse, PackageType, PackageTypeRequest, ConfirmCompanyRequest } from "./types";
 import Mapping from "../../mapping/mapping";
 import { Failure, Result, Success } from "../result";
-import { addReuestIdHeader } from "../../util";
+import { addRequestIdHeader } from "../../util";
 
 const HTTP_STATUS_OK = 200;
 const HTTP_STATUS_NOT_FOUND = 404;
@@ -36,7 +36,7 @@ export class AccountsFilingService {
      */
     public async confirmCompany (companyNumber: string, transactionId: string, confirmCompanyRequest: ConfirmCompanyRequest, requestId?: string): Promise<Resource<AccountsFilingCompanyResponse>> {
         const url = `/transactions/${transactionId}/accounts-filing/company/${companyNumber}/confirm`;
-        const headers = addReuestIdHeader(requestId);
+        const headers = addRequestIdHeader(requestId);
         const resp = await this.client.httpPut(url, confirmCompanyRequest, headers);
 
         const resource: Resource<AccountsFilingCompanyResponse> = {
@@ -218,7 +218,7 @@ export class AccountsFilingService {
         }
 
         const requestBody = Mapping.snakeCaseKeys(packageTypeRequest);
-        const headers = addReuestIdHeader(requestId)
+        const headers = addRequestIdHeader(requestId)
         const resp = await this.client.httpPut(url, requestBody, headers);
 
         // Needed due to javascripts switch block scoping rules

--- a/src/services/accounts-filing/service.ts
+++ b/src/services/accounts-filing/service.ts
@@ -1,0 +1,304 @@
+import { IHttpClient, HttpResponse } from "../../http";
+import Resource, { ApiErrorResponse } from "../resource";
+import { isAccountValidatorResponse } from "../../services/account-validator/types";
+import { AccountsFilingValidationRequest, AccountsFileValidationResponse, AccountsFilingCompanyResponse, PackageType, PackageTypeRequest, ConfirmCompanyRequest } from "./types";
+import Mapping from "../../mapping/mapping";
+import { Failure, Result, Success } from "../result";
+
+const HTTP_STATUS_OK = 200;
+const HTTP_STATUS_NOT_FOUND = 404;
+const HTTP_STATUS_INTERNAL_SERVER_ERROR = 500;
+
+/**
+ * A service class for managing communications with the accounts filing API.
+ * This class serves as the interface for various interactions with the accounts filing system.
+ * Currently, it includes functionality to check the validation status of an accounts file,
+ * but it is designed to accommodate additional features and communications with the accounts filing API
+ * as they are implemented.
+ *
+ * The service handles various HTTP response scenarios, providing appropriate
+ * responses based on the different statuses encountered during the file validation process
+ * or other interactions with the accounts filing API.
+ */
+export class AccountsFilingService {
+    /**
+     * Constructs an AccountsFilingService instance.
+     * @param client - The HTTP client for making requests.
+     */
+    constructor (private readonly client: IHttpClient) {}
+
+    /**
+     * This service will submit the required input from the web to confirm the company.
+     * @param companyNumber The company number
+     * @param transactionId The transaction Id
+     * @returns the company response.
+     */
+    public async confirmCompany (companyNumber: string, transactionId: string, confirmCompanyRequest: ConfirmCompanyRequest): Promise<Resource<AccountsFilingCompanyResponse>> {
+        const url = `/transactions/${transactionId}/accounts-filing/company/${companyNumber}/confirm`;
+        const resp = await this.client.httpPut(url, confirmCompanyRequest);
+
+        const resource: Resource<AccountsFilingCompanyResponse> = {
+            httpStatusCode: resp.status
+        };
+
+        if (resp.error) {
+            return resource;
+        }
+
+        const body = resp.body as AccountsFilingCompanyResponse;
+
+        resource.resource = Mapping.camelCaseKeys<AccountsFilingCompanyResponse>(body);
+
+        return resource;
+    }
+
+    /**
+     * Checks the validation status of an accounts file.
+     * Calls the accounts filing api, which in turn calls the accounts validation service.
+     * @param fileValidationRequest - The request details for file validation.
+     * @returns A promise that resolves to the validation response or an error.
+     */
+    async checkAccountsFileValidationStatus (
+        fileValidationRequest: AccountsFilingValidationRequest
+    ): Promise<Resource<AccountsFileValidationResponse> | ApiErrorResponse> {
+        try {
+            const response = await this.getFileValidationRequest(fileValidationRequest);
+            return this.processResponse(response, fileValidationRequest.fileId);
+        } catch (error) {
+            return this.handleError(error);
+        }
+    }
+
+    /**
+     * Initiates an HTTP GET request to retrieve the status of a file validation process.
+     * This method queries the server for the current validation status of a specific file
+     * associated with an accounts filing and transaction ID.
+     *
+     * @param fileValidationRequest - An object containing the identifiers needed to locate the file.
+     *        This includes the file ID, accounts filing ID, and transaction ID.
+     * @returns A promise that resolves to the HTTP response from the server. The response includes
+     *          the current status of the file validation process.
+     * @throws Will throw an error if the HTTP request fails.
+     */
+    private async getFileValidationRequest (fileValidationRequest: AccountsFilingValidationRequest) {
+        const { fileId, accountsFilingId, transactionId } = fileValidationRequest;
+        return await this.client.httpGet(
+            `/transactions/${transactionId}/accounts-filing/${accountsFilingId}/file/${fileId}/status`
+        );
+    }
+
+    /**
+     * Processes the HTTP response from the file validation request.
+     * This method examines the HTTP status code of the response and delegates
+     * to the appropriate handler based on the status code.
+     *
+     * @param response - The HttpResponse object received from the file validation request.
+     *        It includes the status code and the response data from the server.
+     * @param fileId - The unique identifier of the file whose validation status is being checked.
+     * @returns Depending on the response status, this method can return:
+     *          - The result of the handleOkResponse method if the status is HTTP_STATUS_OK (200),
+     *            indicating a successful response from the server.
+     *          - The result of the fileNotFoundResponse method if the status is HTTP_STATUS_NOT_FOUND (404),
+     *            indicating that the file was not found on the server.
+     *          - The result of the handleUnexpectedStatus method for any other unexpected status codes,
+     *            handling any unforeseen responses.
+     */
+    private processResponse (response: HttpResponse, fileId: string) {
+        switch (response.status) {
+        case HTTP_STATUS_OK:
+            return this.handleOkResponse(response, fileId);
+
+        case HTTP_STATUS_NOT_FOUND:
+            return this.fileNotFoundResponse(fileId);
+
+        default:
+            return this.handleUnexpectedStatus(response);
+        }
+    }
+
+    /**
+     * Handles unexpected HTTP response statuses received from the file validation request.
+     * This method is used as a catch-all for any HTTP status codes that are not specifically
+     * handled in the processResponse method. It constructs a standardized error response
+     * which can be used to notify the caller of an unexpected condition.
+     *
+     * @param response - The HttpResponse object received from the file validation request.
+     *        This includes the status code and any associated response data.
+     * @returns An ApiErrorResponse object that encapsulates the unexpected status code and
+     *          a descriptive error message. This response can be used to inform the user
+     *          or calling function about the unexpected server behavior.
+     */
+    private handleUnexpectedStatus (response: HttpResponse): ApiErrorResponse {
+        return {
+            httpStatusCode: response.status,
+            errors: [{
+                error: `Unexpected server response: Status Code ${response.status}`
+            }]
+        };
+    }
+
+    /**
+     * Handles the OK response received from the file validation request.
+     * This method checks if the response body conforms to the AccountValidatorResponse structure.
+     * If it does, the method returns a successful response, otherwise, it delegates to
+     * the invalidResponseType method for further handling.
+     *
+     * @param response - The HttpResponse object received, expected with a status of HTTP_STATUS_OK.
+     * @param fileId - The unique identifier of the file whose validation status is being checked.
+     * @returns An object with the HTTP status code and the validated response body,
+     *          or the result of the invalidResponseType method in case of an incorrect response type.
+     */
+    private handleOkResponse (response: HttpResponse, fileId: string) {
+        if (isAccountValidatorResponse(response.body)) {
+            return {
+                httpStatusCode: response.status,
+                resource: response.body
+            };
+        }
+
+        return this.invalidResponseType(fileId, response);
+    }
+
+    /**
+     * Generates a standardized error response for the scenario where the requested file is not found.
+     *
+     * @param fileId - The unique identifier of the file that was not found.
+     * @returns An ApiErrorResponse object with the HTTP status of NOT FOUND and an error message.
+     */
+    private fileNotFoundResponse (fileId: string) {
+        return {
+            httpStatusCode: HTTP_STATUS_NOT_FOUND,
+            errors: [{ error: `File with ID [${fileId}] not found.` }]
+        };
+    }
+
+    /**
+     * Constructs an error response for situations where the file validation response is not of the expected type.
+     *
+     * @param fileId - The unique identifier of the file for which the validation response is incorrect.
+     * @param response - The original HttpResponse object received from the file validation request.
+     * @returns An ApiErrorResponse object encapsulating the actual HTTP status and a descriptive error message,
+     *          including the response received for debugging purposes.
+     */
+    private invalidResponseType (fileId: string, response: HttpResponse) {
+        return {
+            httpStatusCode: response.status,
+            errors: [{
+                error: `File validation response for file [${fileId}] is not the correct type. Response: ${JSON.stringify(response.body, null, 2)}`
+            }]
+        };
+    }
+
+    /**
+     * Generic error handling method to capture and process exceptions or errors encountered during
+     * the file validation request process. Converts unhandled errors into a standardized API error response.
+     *
+     * @param error - The error or exception caught during the execution of the file validation request.
+     * @returns An ApiErrorResponse object with the status of INTERNAL_SERVER_ERROR for unhandled errors,
+     *          or the original ApiErrorResponse if the error is already in this format.
+     */
+    private handleError (error: any) {
+        if (isApiErrorResponse(error)) {
+            return error;
+        }
+
+        return {
+            httpStatusCode: HTTP_STATUS_INTERNAL_SERVER_ERROR,
+            errors: [{ error: "Internal Server Error" }]
+        };
+    }
+
+    public async setPackageType (transactionId: string, accountsFilingId: string, packageType: PackageType): Promise<Result<void, Error>> {
+        const url = `/transactions/${transactionId}/accounts-filing/${accountsFilingId}`;
+
+        const packageTypeRequest: PackageTypeRequest = {
+            packageType: packageType
+        }
+
+        const requestBody = Mapping.snakeCaseKeys(packageTypeRequest);
+        const resp = await this.client.httpPut(url, requestBody);
+
+        // Needed due to javascripts switch block scoping rules
+        let errorMessage = "";
+        switch (resp.status) {
+        case 204:
+            return new Success(undefined);
+        case 404:
+            // The api only checks to see if a transaction with the given id exists. No such test is performed for the accountsFilingId.
+            errorMessage = `No transaction with id [${transactionId}] found`;
+            return new Failure(new Error(errorMessage));
+        default:
+            var errorMessageData = {
+                httpStatusCode: resp.status,
+                transactionId,
+                accountsFilingId,
+                responseBody: resp.body
+            }
+            errorMessage = `An unknown error occured when setting accounts filing package type. ${JSON.stringify(errorMessageData, null, 2)}`;
+            return new Failure(new Error(errorMessage));
+        }
+    }
+}
+
+/**
+ * Type guard function to check if a given object conforms to the ApiErrorResponse interface.
+ * This function performs structural validation by checking the existence and types of certain properties
+ * expected in a standard ApiErrorResponse. It is used to determine if an arbitrary object can be treated
+ * as an ApiErrorResponse, typically in error handling scenarios.
+ *
+ * @param object - The object to be checked. It can be any type, as the function will verify its structure.
+ * @returns A boolean value indicating whether the object is an ApiErrorResponse. Returns true if the object
+ *          has the expected structure of an ApiErrorResponse, false otherwise.
+ *
+ * The function checks for the following properties:
+ * - httpStatusCode: Must exist and be of type number.
+ * - errors: Must exist and be an array. Each item in the array must be an object with specific properties
+ *   like 'error', 'errorValues', 'location', 'locationType', and 'type', each with appropriate types.
+ */
+function isApiErrorResponse (object: any): object is ApiErrorResponse {
+    if (
+        object.hasOwnProperty("httpStatusCode") &&
+        typeof object.httpStatusCode !== "number"
+    ) {
+        return false;
+    }
+
+    if (object.hasOwnProperty("errors")) {
+        if (!Array.isArray(object.errors)) {
+            return false;
+        }
+
+        for (const error of object.errors) {
+            if (typeof error !== "object" || error === null) {
+                return false;
+            }
+
+            if (error.hasOwnProperty("error") && typeof error.error !== "string") {
+                return false;
+            }
+            if (
+                error.hasOwnProperty("errorValues") &&
+                typeof error.errorValues !== "object"
+            ) {
+                return false;
+            }
+            if (
+                error.hasOwnProperty("location") &&
+                typeof error.location !== "string"
+            ) {
+                return false;
+            }
+            if (
+                error.hasOwnProperty("locationType") &&
+                typeof error.locationType !== "string"
+            ) {
+                return false;
+            }
+            if (error.hasOwnProperty("type") && typeof error.type !== "string") {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}

--- a/src/services/accounts-filing/types.ts
+++ b/src/services/accounts-filing/types.ts
@@ -1,0 +1,45 @@
+import { AccountValidatorResponse } from "../account-validator/types";
+
+export type AccountsFileValidationResponse = AccountValidatorResponse;
+
+const packageTypes = [
+    "uksef",
+    "cic",
+    "welsh",
+    "limited-partnership",
+    "group-package-400",
+    "group-package-401",
+    "overseas",
+    "audit-exempt-subsidiary",
+    "filing-exempt-subsidiary"
+] as const;
+
+type ElementType<T extends ReadonlyArray<unknown>> = T extends ReadonlyArray<
+    infer ElementType
+>
+    ? ElementType
+    : never;
+
+export type PackageType = ElementType<typeof packageTypes>;
+
+export function isPackageType (o: any): o is PackageType {
+    return packageTypes.includes(o);
+}
+
+export interface AccountsFilingValidationRequest {
+    fileId: string;
+    accountsFilingId: string;
+    transactionId: string;
+}
+
+export interface AccountsFilingCompanyResponse {
+    accountsFilingId: string;
+}
+
+export interface PackageTypeRequest {
+    packageType: PackageType;
+}
+
+export interface ConfirmCompanyRequest {
+    companyName: String;
+}

--- a/src/services/transaction/service.ts
+++ b/src/services/transaction/service.ts
@@ -1,7 +1,7 @@
 import { IHttpClient } from "../../http";
 import { Transaction, TransactionResource } from "./types";
 import Resource, { ApiErrorResponse, ApiResponse } from "../resource";
-import { REQUEST_ID_HEADER } from "../../config";
+import { addReuestIdHeader } from "../../util";
 
 export default class TransactionService {
     constructor (private readonly client: IHttpClient) { }
@@ -11,7 +11,7 @@ export default class TransactionService {
    *
    * @param transaction the transaction to create
    */
-    public async postTransaction (transaction: Transaction): Promise<Resource<Transaction>|ApiErrorResponse> {
+    public async postTransaction (transaction: Transaction, requestId?: string): Promise<Resource<Transaction>|ApiErrorResponse> {
         let url = "/transactions"
         if (transaction.id) {
             url += "/" + transaction.id
@@ -19,7 +19,8 @@ export default class TransactionService {
 
         const transactionResource: TransactionResource = this.mapToResource(transaction);
 
-        const resp = await this.client.httpPost(url, transactionResource);
+        const headers = addReuestIdHeader(requestId);
+        const resp = await this.client.httpPost(url, transactionResource, headers);
 
         if (resp.error) {
             return {
@@ -50,7 +51,7 @@ export default class TransactionService {
     public async putTransaction (transaction: Transaction, requestId?: string): Promise<ApiResponse<Transaction> | ApiErrorResponse> {
         const url = "/transactions/" + transaction.id
 
-        const headers = requestId !== undefined ? { REQUEST_ID_HEADER: requestId } : undefined;
+        const headers = addReuestIdHeader(requestId);
 
         const transactionResource: TransactionResource = this.mapToResource(transaction);
         const resp = await this.client.httpPut(url, transactionResource, headers);
@@ -93,9 +94,10 @@ export default class TransactionService {
      *
      * @param transactionId the id of the transaction to retrieve
      */
-    public async getTransaction (transactionId: string): Promise<Resource<Transaction>|ApiErrorResponse> {
+    public async getTransaction (transactionId: string, requestId?: string): Promise<Resource<Transaction>|ApiErrorResponse> {
         const url = "/transactions/" + transactionId
-        const resp = await this.client.httpGet(url);
+        const headers = addReuestIdHeader(requestId);
+        const resp = await this.client.httpGet(url, headers);
 
         if (resp.error) {
             return {
@@ -135,9 +137,10 @@ export default class TransactionService {
      * @param transactionId the ID of the transaction to update
      * @param transactionResource the partial transaction resource with updates
      */
-    public async patchTransaction (transactionId: string, transactionResource: Partial<TransactionResource>): Promise<Resource<Transaction> | ApiErrorResponse> {
+    public async patchTransaction (transactionId: string, transactionResource: Partial<TransactionResource>, requestId?: string): Promise<Resource<Transaction> | ApiErrorResponse> {
         const url = `/transactions/${transactionId}`;
-        const resp = await this.client.httpPatch(url, transactionResource);
+        const headers = addReuestIdHeader(requestId);
+        const resp = await this.client.httpPatch(url, transactionResource, headers);
 
         if (resp.error) {
             return {

--- a/src/services/transaction/service.ts
+++ b/src/services/transaction/service.ts
@@ -1,7 +1,7 @@
 import { IHttpClient } from "../../http";
 import { Transaction, TransactionResource } from "./types";
 import Resource, { ApiErrorResponse, ApiResponse } from "../resource";
-import { addReuestIdHeader } from "../../util";
+import { addRequestIdHeader } from "../../util";
 
 export default class TransactionService {
     constructor (private readonly client: IHttpClient) { }
@@ -19,7 +19,7 @@ export default class TransactionService {
 
         const transactionResource: TransactionResource = this.mapToResource(transaction);
 
-        const headers = addReuestIdHeader(requestId);
+        const headers = addRequestIdHeader(requestId);
         const resp = await this.client.httpPost(url, transactionResource, headers);
 
         if (resp.error) {
@@ -51,7 +51,7 @@ export default class TransactionService {
     public async putTransaction (transaction: Transaction, requestId?: string): Promise<ApiResponse<Transaction> | ApiErrorResponse> {
         const url = "/transactions/" + transaction.id
 
-        const headers = addReuestIdHeader(requestId);
+        const headers = addRequestIdHeader(requestId);
 
         const transactionResource: TransactionResource = this.mapToResource(transaction);
         const resp = await this.client.httpPut(url, transactionResource, headers);
@@ -96,7 +96,7 @@ export default class TransactionService {
      */
     public async getTransaction (transactionId: string, requestId?: string): Promise<Resource<Transaction>|ApiErrorResponse> {
         const url = "/transactions/" + transactionId
-        const headers = addReuestIdHeader(requestId);
+        const headers = addRequestIdHeader(requestId);
         const resp = await this.client.httpGet(url, headers);
 
         if (resp.error) {
@@ -139,7 +139,7 @@ export default class TransactionService {
      */
     public async patchTransaction (transactionId: string, transactionResource: Partial<TransactionResource>, requestId?: string): Promise<Resource<Transaction> | ApiErrorResponse> {
         const url = `/transactions/${transactionId}`;
-        const headers = addReuestIdHeader(requestId);
+        const headers = addRequestIdHeader(requestId);
         const resp = await this.client.httpPatch(url, transactionResource, headers);
 
         if (resp.error) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -13,7 +13,7 @@ import { Headers } from "./http";
  * @param {Headers} otherHeaders Existing set of headers to which the Request ID header will be added.
  * @returns {Headers | undefined} A new headers object with the Request ID added, or undefined if no Request ID was provided.
  */
-export function addReuestIdHeader (requestId?: string, otherHeaders: Headers = {}): Headers | undefined {
+export function addRequestIdHeader (requestId?: string, otherHeaders: Headers = {}): Headers | undefined {
     if (requestId === undefined) {
         return undefined
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,24 @@
+import { REQUEST_ID_HEADER } from "./config";
+import { Headers } from "./http";
+
+/**
+ * Adds a Request ID header to the existing headers, if the Request ID is provided.
+ *
+ * The Request ID header is utilised to correlate requests between services, allowing
+ * for easier tracking of how requests propagate through a system of microservices.
+ * It is also used as a context key for logger systems to maintain tracing information
+ * across service calls.
+ *
+ * @param {string | undefined} requestId The unique identifier for the request, used for tracing.
+ * @param {Headers} otherHeaders Existing set of headers to which the Request ID header will be added.
+ * @returns {Headers | undefined} A new headers object with the Request ID added, or undefined if no Request ID was provided.
+ */
+export function addReuestIdHeader (requestId?: string, otherHeaders: Headers = {}): Headers | undefined {
+    if (requestId === undefined) {
+        return undefined
+    }
+
+    otherHeaders = otherHeaders !== undefined ? otherHeaders : {}
+
+    return { ...otherHeaders, [REQUEST_ID_HEADER]: requestId };
+}

--- a/test/services/accounts-filing/service.spec.ts
+++ b/test/services/accounts-filing/service.spec.ts
@@ -1,0 +1,335 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import { IHttpClient, RequestClient } from "../../../src/http";
+import { AccountsFilingService } from "../../../src/services/accounts-filing/service";
+import { AccountValidatorResponse } from "../../../src/services/account-validator/types";
+import Resource, { ApiErrorResponse } from "../../../src/services/resource";
+import {
+    AccountsFilingValidationRequest,
+    AccountsFilingCompanyResponse,
+    ConfirmCompanyRequest
+} from "../../../src/services/accounts-filing/types";
+import { Failure } from "../../../src/services/result";
+
+function createApiResponse (fileId: string) {
+    return {
+        fileId,
+        fileName: "1mb.zip",
+        status: "complete",
+        result: {
+            validationStatus: "FAILED",
+            data: {
+                balance_sheet_date: "UNKNOWN",
+                accounts_type: "00",
+                companieshouse_registered_number: "UNKNOWN"
+            },
+            errorMessages: [
+                {
+                    errorMessage: "Found 2 inline XBRL documents."
+                },
+                {
+                    errorMessage:
+                        "The submission contains a malformed XML document: image1689926429N.html"
+                }
+            ]
+        }
+    };
+}
+
+describe("AccountsFilingService", () => {
+    let httpClient: IHttpClient;
+    let accountsFilingService: AccountsFilingService;
+
+    beforeEach(() => {
+        httpClient = new RequestClient({
+            baseUrl: "URL-NOT-USED",
+            oauthToken: "TOKEN-NOT-USED"
+        });
+        accountsFilingService = new AccountsFilingService(httpClient);
+    });
+
+    describe("confirmCompany", () => {
+        it("should returns 200 response with accountsFilingId", async () => {
+            const mockCompanyResponse = {
+                status: 200,
+                body: {
+                    accountsFilingId: "mockAccountsFilingId"
+                }
+            };
+
+            const companyNumber = "CN123456";
+            const transactionId = "000000-123456-000000";
+            const confirmCompanyRequest: ConfirmCompanyRequest = {
+                companyName: "Test Company"
+            };
+
+            sinon.stub(httpClient, "httpPut").resolves(mockCompanyResponse);
+            await accountsFilingService
+                .confirmCompany(
+                    companyNumber,
+                    transactionId,
+                    confirmCompanyRequest
+                )
+                .then((data) => {
+                    expect(data.httpStatusCode).to.equal(200);
+                    const castedData: Resource<AccountsFilingCompanyResponse> =
+                        data as Resource<AccountsFilingCompanyResponse>;
+
+                    expect(castedData?.resource?.accountsFilingId).to.equal(
+                        "mockAccountsFilingId"
+                    );
+                });
+        });
+
+        it("get returns a 400 when invalid company number is passed", async () => {
+            const mockErrorResponse = {
+                status: 400,
+                body: "Mocked error message"
+            };
+
+            const companyNumber = "";
+            const transactionId = "000000-123456-000000";
+            const confirmCompanyRequest: ConfirmCompanyRequest = {
+                companyName: "Test Company"
+            };
+
+            sinon.stub(httpClient, "httpPut").resolves(mockErrorResponse);
+            await accountsFilingService
+                .confirmCompany(
+                    companyNumber,
+                    transactionId,
+                    confirmCompanyRequest
+                )
+                .then((data) => {
+                    expect(data.httpStatusCode).to.equal(400);
+                });
+        });
+
+        it("get returns a 400 when invalid transaction id is passed", async () => {
+            const mockErrorResponse = {
+                status: 400,
+                body: "Mocked error message"
+            };
+
+            const companyNumber = "CN123456";
+            const transactionId = "123456-000000";
+            const confirmCompanyRequest: ConfirmCompanyRequest = {
+                companyName: "Test Company"
+            };
+
+            sinon.stub(httpClient, "httpPut").resolves(mockErrorResponse);
+            await accountsFilingService
+                .confirmCompany(
+                    companyNumber,
+                    transactionId,
+                    confirmCompanyRequest
+                )
+                .then((data) => {
+                    expect(data.httpStatusCode).to.equal(400);
+                });
+        });
+
+        it("Return 500 during unhandled runtime exception. For example mongodb services are down. ", async () => {
+            const mockErrorResponse = {
+                status: 500,
+                body: "Mocked error message"
+            };
+
+            const companyNumber = "CN123456";
+            const transactionId = "000000-123456-000000";
+            const confirmCompanyRequest: ConfirmCompanyRequest = {
+                companyName: "Test Company"
+            };
+
+            sinon.stub(httpClient, "httpPut").resolves(mockErrorResponse);
+            await accountsFilingService
+                .confirmCompany(
+                    companyNumber,
+                    transactionId,
+                    confirmCompanyRequest
+                )
+                .then((data) => {
+                    expect(data.httpStatusCode).to.equal(500);
+                });
+        });
+    });
+
+    describe("checkAccountsFileValidationStatus", () => {
+        it("should handle a successful response correctly", async () => {
+            const fileId = "f37c5268-ecd2-4b62-a19e-ecb343d2c017";
+            const accountsFilingApiResponse = createApiResponse(fileId);
+
+            const getStub = sinon.stub(httpClient, "httpGet").resolves({
+                status: 200,
+                body: accountsFilingApiResponse
+            });
+
+            const fileValidationRequest: AccountsFilingValidationRequest = {
+                fileId,
+                accountsFilingId: "456",
+                transactionId: "789"
+            };
+
+            const resp =
+                await accountsFilingService.checkAccountsFileValidationStatus(
+                    fileValidationRequest
+                );
+
+            expect(resp.httpStatusCode).equal(200);
+            expect(resp).to.have.property("resource");
+
+            const _resp = resp as Resource<AccountValidatorResponse>;
+            expect(_resp.resource).to.not.be.undefined;
+            expect(_resp.resource?.fileId).to.equal(fileId);
+
+            getStub.restore();
+        });
+
+        it("should handle a 'file not found' response correctly", async () => {
+            const fileId = "f37c5268-ecd2-4b62-a19e-ecb343d2c017";
+
+            const getStub = sinon.stub(httpClient, "httpGet").resolves({
+                status: 404
+            });
+
+            const fileValidationRequest: AccountsFilingValidationRequest = {
+                fileId,
+                accountsFilingId: "456",
+                transactionId: "789"
+            };
+
+            const resp =
+                await accountsFilingService.checkAccountsFileValidationStatus(
+                    fileValidationRequest
+                );
+
+            expect(resp.httpStatusCode).equal(404);
+            expect(resp).to.have.property("errors");
+            expect((resp as ApiErrorResponse)?.errors?.[0]?.error).to.include(
+                "not found"
+            );
+
+            getStub.restore();
+        });
+
+        it("should handle an unexpected error response correctly", async () => {
+            const fileId = "123";
+            const unexpectedError = { message: "Unexpected error" };
+
+            const getStub = sinon.stub(httpClient, "httpGet").resolves({
+                status: 500,
+                body: unexpectedError
+            });
+
+            const fileValidationRequest: AccountsFilingValidationRequest = {
+                fileId,
+                accountsFilingId: "456",
+                transactionId: "789"
+            };
+
+            const resp =
+                await accountsFilingService.checkAccountsFileValidationStatus(
+                    fileValidationRequest
+                );
+
+            expect(resp).to.be.an("object");
+            expect(resp.httpStatusCode).to.equal(500);
+            expect(resp).to.have.property("errors");
+            expect((resp as ApiErrorResponse)?.errors?.[0]?.error).to.equal(
+                "Unexpected server response: Status Code 500"
+            );
+
+            getStub.restore();
+        });
+
+        it("should handle exceptions correctly", async () => {
+            const fileId = "123";
+            const errorMessage = "Network error";
+
+            const getStub = sinon
+                .stub(httpClient, "httpGet")
+                .rejects(new Error(errorMessage));
+
+            const fileValidationRequest: AccountsFilingValidationRequest = {
+                fileId,
+                accountsFilingId: "456",
+                transactionId: "789"
+            };
+
+            try {
+                await accountsFilingService.checkAccountsFileValidationStatus(
+                    fileValidationRequest
+                );
+                expect.fail("Expected method to throw an error.");
+            } catch (error) {
+                expect(error).to.be.an.instanceOf(Error);
+                expect(error.message).to.equal(
+                    "Expected method to throw an error."
+                );
+            } finally {
+                getStub.restore();
+            }
+        });
+    });
+
+    describe("setPackageType", () => {
+        it("Should return a successful result if the return status is 204", async () => {
+            const putStub = sinon.stub(httpClient, "httpPut").resolves({
+                status: 204
+            });
+
+            try {
+                const result = await accountsFilingService.setPackageType(
+                    "tx_id",
+                    "af_id",
+                    "uksef"
+                );
+                expect(result.isSuccess()).to.be.true;
+            } finally {
+                putStub.restore();
+            }
+        });
+
+        it("Should return a failure message when the return status is 404", async () => {
+            const putStub = sinon.stub(httpClient, "httpPut").resolves({
+                status: 404
+            });
+
+            try {
+                const result = await accountsFilingService.setPackageType(
+                    "tx_id",
+                    "af_id",
+                    "uksef"
+                );
+
+                expect(result.isFailure()).to.be.true;
+                const value = (result as Failure<void, Error>).value;
+                expect(value).to.be.an("Error");
+                expect(value.message).to.contain("No transaction with id");
+            } finally {
+                putStub.restore();
+            }
+        });
+
+        it("Should return a generic failure message when the return status is not 204 or 404", async () => {
+            const putStub = sinon.stub(httpClient, "httpPut").resolves({
+                status: 500
+            });
+
+            try {
+                const result = await accountsFilingService.setPackageType(
+                    "tx_id",
+                    "af_id",
+                    "uksef"
+                );
+
+                expect(result.isFailure()).to.be.true;
+                const value = (result as Failure<void, Error>).value;
+                expect(value).to.be.an("Error");
+                expect(value.message).to.contain("An unknown error occured");
+            } finally {
+                putStub.restore();
+            }
+        });
+    });
+});


### PR DESCRIPTION
As part of moving the `accounts-filing-api` from the internal API to the external API, the `accounts-filing` service is moved from the `private-api-sdk-node` to the `api-sdk-node`.

Once this PR has been mereged and released, the `accounts-filing` service will be removed from the `private-api-sdk-node`.

The `accounts-filing` types relied on type from the `account-validator` service which is in the private sdk. Since the public SDK cannot access the private one, these types have been moved too and services which use the account validator node sdk will have to updated to refer to the types from the api-sdk-node instead.


Additionally, this PR adds the ability to set the requestID header for the accounts-filing service as well as the transactions service. This will aid 