### PR TITLE
UAR-1402 Update save and resume ids for BOs and MOs

### DIFF
--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -123,6 +123,7 @@ export interface OverseasEntityDueDiligenceResource {
 }
 
 export interface BeneficialOwnerIndividual {
+    id?: string
     ch_reference?: string
     first_name?: string
     last_name?: string
@@ -142,6 +143,7 @@ export interface BeneficialOwnerIndividual {
 }
 
 export interface BeneficialOwnerIndividualResource {
+    id?: string
     ch_reference?: string
     first_name?: string
     last_name?: string
@@ -630,7 +632,7 @@ export interface TrustLinkDataResource {
 export interface IndividualTrusteeData {
     hashedTrusteeId: string;
     trusteeForename1: string;
-    trusteeForename2?: string;
+    trusteeForename2?: string;  
     trusteeSurname: string;
     dateOfBirth?: string;
     nationality?: string;

--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -655,7 +655,7 @@ export interface TrustLinkDataResource {
 export interface IndividualTrusteeData {
     hashedTrusteeId: string;
     trusteeForename1: string;
-    trusteeForename2?: string;  
+    trusteeForename2?: string;
     trusteeSurname: string;
     dateOfBirth?: string;
     nationality?: string;

--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -163,6 +163,7 @@ export interface BeneficialOwnerIndividualResource {
 }
 
 export interface BeneficialOwnerCorporate {
+    id?: string
     ch_reference?: string
     name?: string
     principal_address?: Address
@@ -182,6 +183,7 @@ export interface BeneficialOwnerCorporate {
 }
 
 export interface BeneficialOwnerCorporateResource {
+    id?: string
     ch_reference?: string
     name?: string
     principal_address?: Address

--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -203,6 +203,7 @@ export interface BeneficialOwnerCorporateResource {
 }
 
 export interface BeneficialOwnerGovernmentOrPublicAuthority {
+    id?: string
     ch_reference?: string
     name?: string
     principal_address?: Address
@@ -216,6 +217,7 @@ export interface BeneficialOwnerGovernmentOrPublicAuthority {
     non_legal_firm_members_nature_of_control_types?: NatureOfControlType[];
 }
 export interface BeneficialOwnerGovernmentOrPublicAuthorityResource {
+    id?: string
     ch_reference?: string
     name?: string
     principal_address?: Address
@@ -248,6 +250,7 @@ export interface BeneficialOwnerPrivateData {
 }
 
 export interface ManagingOfficerIndividual {
+    id?: string
     ch_reference?: string
     first_name?: string
     last_name?: string
@@ -267,6 +270,7 @@ export interface ManagingOfficerIndividual {
 }
 
 export interface ManagingOfficerIndividualResource {
+    id?: string
     ch_reference?: string
     first_name?: string
     last_name?: string
@@ -286,6 +290,7 @@ export interface ManagingOfficerIndividualResource {
 }
 
 export interface ManagingOfficerCorporate {
+    id?: string
     ch_reference?: string
     name?: string
     principal_address?: Address
@@ -346,6 +351,7 @@ export interface UpdateResource {
 }
 
 export interface ManagingOfficerCorporateResource {
+    id?: string
     ch_reference?: string
     name?: string
     principal_address?: Address


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/UAR-1402

Ids were not being saved to Mongo when BOs and MOs moved out of review on an Update/Remove journey. This then caused various issues if the submission was saved and later resumed. Ids are now sent to - and persisted by - the OE API, allowing things to work as expected.