### PR TITLE
ROECCT-245 - Add New field for legal entity beneficiaries to indicate became dates.

### DIFF
--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -204,7 +204,7 @@ const mapToTrust = (trust: TrustResource): Trust => {
                     date_became_interested_person,
                     is_corporate_still_involved_in_trust,
                     ceased_date,
-                    start_date
+                    start_date,
                     ...rest
                 } = trustCorp;
 
@@ -226,7 +226,7 @@ const mapToTrust = (trust: TrustResource): Trust => {
                 still_involved: isInvolved,
                 ceased_date_day: ceasedDate?.day,
                 ceased_date_month: ceasedDate?.month,
-                ceased_date_year: ceasedDate?.year
+                ceased_date_year: ceasedDate?.year,
                 start_date_day: startDate?.day,
                 start_date_month: startDate?.month,
                 start_date_year: startDate?.year
@@ -475,6 +475,7 @@ const mapTrustCorporates = (trustCorporates: TrustCorporate[] = []): TrustCorpor
             date_became_interested_person_month, date_became_interested_person_year,
             still_involved,
             ceased_date_day, ceased_date_month, ceased_date_year,
+            start_date_day,start_date_month,start_date_year,
             ...rest
         } = trustCorporate;
         return {
@@ -482,7 +483,7 @@ const mapTrustCorporates = (trustCorporates: TrustCorporate[] = []): TrustCorpor
             date_became_interested_person: convertOptionalDateToIsoDateString(date_became_interested_person_day, date_became_interested_person_month, date_became_interested_person_year),
             is_corporate_still_involved_in_trust: still_involved ? (still_involved === "Yes") : null,
             ceased_date: convertOptionalDateToIsoDateString(ceased_date_day, ceased_date_month, ceased_date_year),
-            start_date: convertDateToIsoDateString(start_date?.day, start_date?.month, start_date?.year),
+            start_date: convertOptionalDateToIsoDateString(start_date_day, start_date_month, start_date_year),
         }
     })
 }

--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -210,7 +210,7 @@ const mapToTrust = (trust: TrustResource): Trust => {
 
             const dbipDate = mapIsoDate(date_became_interested_person);
             const ceasedDate = ceased_date ? mapIsoDate(ceased_date) : undefined;
-            const startDate = start_date ? mapIsoDate(start_date) : undefined;
+            const startDate = start_date ? mapIsoDate(start_date) : undefined
 
             let isInvolved = is_corporate_still_involved_in_trust ? "Yes" : "No";
             // If a boolean value isn't receieved from the API (could be null or undefined), need to set null
@@ -475,7 +475,7 @@ const mapTrustCorporates = (trustCorporates: TrustCorporate[] = []): TrustCorpor
             date_became_interested_person_month, date_became_interested_person_year,
             still_involved,
             ceased_date_day, ceased_date_month, ceased_date_year,
-            start_date,
+            start_date_day, start_date_month, start_date_year,
             ...rest
         } = trustCorporate;
         return {
@@ -483,7 +483,7 @@ const mapTrustCorporates = (trustCorporates: TrustCorporate[] = []): TrustCorpor
             date_became_interested_person: convertOptionalDateToIsoDateString(date_became_interested_person_day, date_became_interested_person_month, date_became_interested_person_year),
             is_corporate_still_involved_in_trust: still_involved ? (still_involved === "Yes") : null,
             ceased_date: convertOptionalDateToIsoDateString(ceased_date_day, ceased_date_month, ceased_date_year),
-            start_date: convertOptionalInputDate(start_date)
+            start_date: convertOptionalDateToIsoDateString(start_date_day, start_date_month, start_date_year)
         }
     })
 }

--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -204,11 +204,13 @@ const mapToTrust = (trust: TrustResource): Trust => {
                     date_became_interested_person,
                     is_corporate_still_involved_in_trust,
                     ceased_date,
+                    start_date
                     ...rest
                 } = trustCorp;
 
             const dbipDate = mapIsoDate(date_became_interested_person);
             const ceasedDate = ceased_date ? mapIsoDate(ceased_date) : undefined;
+            const startDate = start_date ? mapIsoDate(start_date) : undefined;
 
             let isInvolved = is_corporate_still_involved_in_trust ? "Yes" : "No";
             // If a boolean value isn't receieved from the API (could be null or undefined), need to set null
@@ -225,6 +227,9 @@ const mapToTrust = (trust: TrustResource): Trust => {
                 ceased_date_day: ceasedDate?.day,
                 ceased_date_month: ceasedDate?.month,
                 ceased_date_year: ceasedDate?.year
+                start_date_day: startDate?.day,
+                start_date_month: startDate?.month,
+                start_date_year: startDate?.year
             }
         })
     }

--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -483,7 +483,7 @@ const mapTrustCorporates = (trustCorporates: TrustCorporate[] = []): TrustCorpor
             date_became_interested_person: convertOptionalDateToIsoDateString(date_became_interested_person_day, date_became_interested_person_month, date_became_interested_person_year),
             is_corporate_still_involved_in_trust: still_involved ? (still_involved === "Yes") : null,
             ceased_date: convertOptionalDateToIsoDateString(ceased_date_day, ceased_date_month, ceased_date_year),
-            start_date: convertOptionalInputDate(start_date),
+            start_date: convertOptionalInputDate(start_date)
         }
     })
 }

--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -475,7 +475,7 @@ const mapTrustCorporates = (trustCorporates: TrustCorporate[] = []): TrustCorpor
             date_became_interested_person_month, date_became_interested_person_year,
             still_involved,
             ceased_date_day, ceased_date_month, ceased_date_year,
-            start_date_day,start_date_month,start_date_year,
+            start_date_day, start_date_month, start_date_year,
             ...rest
         } = trustCorporate;
         return {
@@ -483,7 +483,7 @@ const mapTrustCorporates = (trustCorporates: TrustCorporate[] = []): TrustCorpor
             date_became_interested_person: convertOptionalDateToIsoDateString(date_became_interested_person_day, date_became_interested_person_month, date_became_interested_person_year),
             is_corporate_still_involved_in_trust: still_involved ? (still_involved === "Yes") : null,
             ceased_date: convertOptionalDateToIsoDateString(ceased_date_day, ceased_date_month, ceased_date_year),
-            start_date: convertOptionalDateToIsoDateString(start_date_day, start_date_month, start_date_year),
+            start_date: convertOptionalDateToIsoDateString(start_date_day, start_date_month, start_date_year)
         }
     })
 }

--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -476,7 +476,8 @@ const mapTrustCorporates = (trustCorporates: TrustCorporate[] = []): TrustCorpor
             ...rest,
             date_became_interested_person: convertOptionalDateToIsoDateString(date_became_interested_person_day, date_became_interested_person_month, date_became_interested_person_year),
             is_corporate_still_involved_in_trust: still_involved ? (still_involved === "Yes") : null,
-            ceased_date: convertOptionalDateToIsoDateString(ceased_date_day, ceased_date_month, ceased_date_year)
+            ceased_date: convertOptionalDateToIsoDateString(ceased_date_day, ceased_date_month, ceased_date_year),
+            start_date: convertDateToIsoDateString(start_date?.day, start_date?.month, start_date?.year),
         }
     })
 }

--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -210,7 +210,7 @@ const mapToTrust = (trust: TrustResource): Trust => {
 
             const dbipDate = mapIsoDate(date_became_interested_person);
             const ceasedDate = ceased_date ? mapIsoDate(ceased_date) : undefined;
-            const startDate = mapIsoDate(start_date);
+            const startDate = start_date ? mapIsoDate(start_date) : undefined;
 
             let isInvolved = is_corporate_still_involved_in_trust ? "Yes" : "No";
             // If a boolean value isn't receieved from the API (could be null or undefined), need to set null
@@ -483,7 +483,7 @@ const mapTrustCorporates = (trustCorporates: TrustCorporate[] = []): TrustCorpor
             date_became_interested_person: convertOptionalDateToIsoDateString(date_became_interested_person_day, date_became_interested_person_month, date_became_interested_person_year),
             is_corporate_still_involved_in_trust: still_involved ? (still_involved === "Yes") : null,
             ceased_date: convertOptionalDateToIsoDateString(ceased_date_day, ceased_date_month, ceased_date_year),
-            start_date: convertOptionalInputDate(start_date)
+            start_date: convertOptionalInputDate(start_date),
         }
     })
 }

--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -210,7 +210,7 @@ const mapToTrust = (trust: TrustResource): Trust => {
 
             const dbipDate = mapIsoDate(date_became_interested_person);
             const ceasedDate = ceased_date ? mapIsoDate(ceased_date) : undefined;
-            const startDate = start_date ? mapIsoDate(start_date) : undefined;
+            const startDate = mapIsoDate(start_date);
 
             let isInvolved = is_corporate_still_involved_in_trust ? "Yes" : "No";
             // If a boolean value isn't receieved from the API (could be null or undefined), need to set null
@@ -475,7 +475,7 @@ const mapTrustCorporates = (trustCorporates: TrustCorporate[] = []): TrustCorpor
             date_became_interested_person_month, date_became_interested_person_year,
             still_involved,
             ceased_date_day, ceased_date_month, ceased_date_year,
-            start_date_day, start_date_month, start_date_year,
+            start_date,
             ...rest
         } = trustCorporate;
         return {
@@ -483,7 +483,7 @@ const mapTrustCorporates = (trustCorporates: TrustCorporate[] = []): TrustCorpor
             date_became_interested_person: convertOptionalDateToIsoDateString(date_became_interested_person_day, date_became_interested_person_month, date_became_interested_person_year),
             is_corporate_still_involved_in_trust: still_involved ? (still_involved === "Yes") : null,
             ceased_date: convertOptionalDateToIsoDateString(ceased_date_day, ceased_date_month, ceased_date_year),
-            start_date: convertOptionalDateToIsoDateString(start_date_day, start_date_month, start_date_year)
+            start_date: convertOptionalInputDate(start_date)
         }
     })
 }

--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -601,9 +601,7 @@ export interface TrustCorporate {
     ceased_date_day?: string;
     ceased_date_month?: string;
     ceased_date_year?: string;
-    start_date_day?: string;
-    start_date_month?: string;
-    start_date_year?: string;
+    start_date?: InputDate;
 
 }
 

--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -601,6 +601,9 @@ export interface TrustCorporate {
     ceased_date_day?: string;
     ceased_date_month?: string;
     ceased_date_year?: string;
+    start_date_day?: string;
+    start_date_month?: string;
+    start_date_year?: string;
 
 }
 
@@ -636,6 +639,7 @@ export interface TrustCorporateResource {
     is_on_register_in_country_formed_in: yesNoResponse;
     is_corporate_still_involved_in_trust?: boolean;
     ceased_date? : string;
+    start_date?: string;
 }
 
 /**

--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -601,7 +601,9 @@ export interface TrustCorporate {
     ceased_date_day?: string;
     ceased_date_month?: string;
     ceased_date_year?: string;
-    start_date?: InputDate;
+    start_date_day?: string;
+    start_date_month?: string;
+    start_date_year?: string;
 
 }
 

--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -717,6 +717,7 @@ export interface CorporateTrusteeData {
     trusteeTypeId: string;
     appointmentDate: string;
     ceasedDate?: string;
+    startDate?: string;
     serviceAddress?: PrivateAddress;
     registeredOfficeAddress?: PrivateAddress;
 }
@@ -734,6 +735,7 @@ export interface CorporateTrusteeDataResource {
     trustee_type_id: string;
     appointment_date: string;
     ceased_date?: string;
+    start_date?: string;
     service_address?: PrivateAddressResource;
     registered_office_address?: PrivateAddressResource;
 }

--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -717,7 +717,6 @@ export interface CorporateTrusteeData {
     trusteeTypeId: string;
     appointmentDate: string;
     ceasedDate?: string;
-    startDate?: string;
     serviceAddress?: PrivateAddress;
     registeredOfficeAddress?: PrivateAddress;
 }
@@ -735,7 +734,6 @@ export interface CorporateTrusteeDataResource {
     trustee_type_id: string;
     appointment_date: string;
     ceased_date?: string;
-    start_date?: string;
     service_address?: PrivateAddressResource;
     registered_office_address?: PrivateAddressResource;
 }

--- a/test/services/overseas-entities/overseas.entities.mock.ts
+++ b/test/services/overseas-entities/overseas.entities.mock.ts
@@ -403,7 +403,7 @@ export const TRUST_CORPORATES_MOCK: TrustCorporate[] = [{
     ceased_date_day: "1",
     ceased_date_month: "9",
     ceased_date_year: "2005",
-    start_date: { day: "1", month: "1", year: "2012" }
+    start_date: { day: "11", month: "5", year: "2006" }
 }]
 
 export const TRUST_HISTORICAL_BOS_MOCK: TrustHistoricalBeneficialOwner[] = [{

--- a/test/services/overseas-entities/overseas.entities.mock.ts
+++ b/test/services/overseas-entities/overseas.entities.mock.ts
@@ -403,7 +403,9 @@ export const TRUST_CORPORATES_MOCK: TrustCorporate[] = [{
     ceased_date_day: "1",
     ceased_date_month: "9",
     ceased_date_year: "2005",
-    start_date: { day: "11", month: "5", year: "2006" }
+    start_date_day: "11",
+    start_date_month: "5",
+    start_date_year: "2006"
 }]
 
 export const TRUST_HISTORICAL_BOS_MOCK: TrustHistoricalBeneficialOwner[] = [{

--- a/test/services/overseas-entities/overseas.entities.mock.ts
+++ b/test/services/overseas-entities/overseas.entities.mock.ts
@@ -843,7 +843,6 @@ export const CORPORATE_TRUSTEES_DATA_MOCK = [{
     trusteeTypeId: "50002",
     appointmentDate: "2020-02-20",
     ceasedDate: "2020-02-20",
-    startDate: "2006-05-11",
     serviceAddress: {
         addressLine1: "sa_addressline1",
         addressLine2: "sa_addressline2",
@@ -880,7 +879,6 @@ export const CORPORATE_TRUSTEES_DATA_RESOURCE_MOCK = [{
     trustee_type_id: "50002",
     appointment_date: "2020-02-20",
     ceased_date: "2020-02-20",
-    start_date: "2006-05-11",
     service_address: {
         address_line_1: "sa_addressline1",
         address_line_2: "sa_addressline2",

--- a/test/services/overseas-entities/overseas.entities.mock.ts
+++ b/test/services/overseas-entities/overseas.entities.mock.ts
@@ -402,7 +402,10 @@ export const TRUST_CORPORATES_MOCK: TrustCorporate[] = [{
     still_involved: "No",
     ceased_date_day: "1",
     ceased_date_month: "9",
-    ceased_date_year: "2005"
+    ceased_date_year: "2005",
+    start_date_day: "11",
+    start_date_month: "5",
+    start_date_year: "2006"
 }]
 
 export const TRUST_HISTORICAL_BOS_MOCK: TrustHistoricalBeneficialOwner[] = [{
@@ -584,7 +587,8 @@ export const TRUST_CORPORATES_RESOURCE_MOCK: TrustCorporateResource[] = [{
     identification_registration_number: "456",
     is_on_register_in_country_formed_in: yesNoResponse.Yes,
     is_corporate_still_involved_in_trust: false,
-    ceased_date: "2005-09-01"
+    ceased_date: "2005-09-01",
+    start_date: "2006-05-11"
 }]
 
 export const TRUST_HISTORICAL_BOS_RESOURCE_MOCK: TrustHistoricalBeneficialOwnerResource[] = [{

--- a/test/services/overseas-entities/overseas.entities.mock.ts
+++ b/test/services/overseas-entities/overseas.entities.mock.ts
@@ -843,6 +843,7 @@ export const CORPORATE_TRUSTEES_DATA_MOCK = [{
     trusteeTypeId: "50002",
     appointmentDate: "2020-02-20",
     ceasedDate: "2020-02-20",
+    startDate: "2006-05-11",
     serviceAddress: {
         addressLine1: "sa_addressline1",
         addressLine2: "sa_addressline2",
@@ -879,6 +880,7 @@ export const CORPORATE_TRUSTEES_DATA_RESOURCE_MOCK = [{
     trustee_type_id: "50002",
     appointment_date: "2020-02-20",
     ceased_date: "2020-02-20",
+    start_date: "2006-05-11",
     service_address: {
         address_line_1: "sa_addressline1",
         address_line_2: "sa_addressline2",

--- a/test/services/overseas-entities/overseas.entities.mock.ts
+++ b/test/services/overseas-entities/overseas.entities.mock.ts
@@ -403,9 +403,7 @@ export const TRUST_CORPORATES_MOCK: TrustCorporate[] = [{
     ceased_date_day: "1",
     ceased_date_month: "9",
     ceased_date_year: "2005",
-    start_date_day: "11",
-    start_date_month: "5",
-    start_date_year: "2006"
+    start_date: { day: "1", month: "1", year: "2012" }
 }]
 
 export const TRUST_HISTORICAL_BOS_MOCK: TrustHistoricalBeneficialOwner[] = [{


### PR DESCRIPTION
Jira Ticket:  https://companieshouse.atlassian.net/browse/ROECCT-245

This involves adding a new field to the legal beneficiary page to allow users to input the date they became a beneficiary. This includes updating the UI to include the new field, validating the input, and ensuring the data is saved correctly in the backend.