### PR TITLE
UAR-1615 New NOCs for Other (Corporate) BOs

### DIFF
--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -193,6 +193,10 @@ export interface BeneficialOwnerCorporate {
     beneficial_owner_nature_of_control_types?: NatureOfControlType[]
     trustees_nature_of_control_types?: NatureOfControlType[]
     non_legal_firm_members_nature_of_control_types?: NatureOfControlType[]
+    non_legal_firm_control_nature_of_control_types?: NatureOfControlType[]
+    trust_control_nature_of_control_types?: NatureOfControlType[]
+    owner_of_land_person_nature_of_control_jurisdictions?: NatureOfControlJurisdictionType[]
+    owner_of_land_other_entity_nature_of_control_jurisdictions?: NatureOfControlJurisdictionType[]
     is_on_sanctions_list?: yesNoResponse
 }
 
@@ -213,6 +217,10 @@ export interface BeneficialOwnerCorporateResource {
     beneficial_owner_nature_of_control_types?: NatureOfControlType[]
     trustees_nature_of_control_types?: NatureOfControlType[]
     non_legal_firm_members_nature_of_control_types?: NatureOfControlType[]
+    non_legal_firm_control_nature_of_control_types?: NatureOfControlType[]
+    trust_control_nature_of_control_types?: NatureOfControlType[]
+    owner_of_land_person_nature_of_control_jurisdictions?: NatureOfControlJurisdictionType[]
+    owner_of_land_other_entity_nature_of_control_jurisdictions?: NatureOfControlJurisdictionType[]
     is_on_sanctions_list?: yesNoResponse
 }
 

--- a/test/services/overseas-entities/overseas.entities.mock.ts
+++ b/test/services/overseas-entities/overseas.entities.mock.ts
@@ -184,6 +184,10 @@ export const BENEFICIAL_OWNER_CORPORATE_MOCK_LIST: BeneficialOwnerCorporate[] = 
         beneficial_owner_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_SHARES],
         trustees_nature_of_control_types: [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS],
         non_legal_firm_members_nature_of_control_types: [NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL],
+        non_legal_firm_control_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_VOTING_RIGHTS],
+        trust_control_nature_of_control_types: [NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL],
+        owner_of_land_person_nature_of_control_jurisdictions: [NatureOfControlJurisdictionType.SCOTLAND],
+        owner_of_land_other_entity_nature_of_control_jurisdictions: [NatureOfControlJurisdictionType.NORTHERN_IRELAND],
         is_on_sanctions_list: yesNoResponse.No
     }
 ];
@@ -204,6 +208,10 @@ export const BENEFICIAL_OWNER_CORPORATE_RESOURCE_MOCK_LIST: BeneficialOwnerCorpo
         beneficial_owner_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_SHARES],
         trustees_nature_of_control_types: [NatureOfControlType.APPOINT_OR_REMOVE_MAJORITY_BOARD_DIRECTORS],
         non_legal_firm_members_nature_of_control_types: [NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL],
+        non_legal_firm_control_nature_of_control_types: [NatureOfControlType.OVER_25_PERCENT_OF_VOTING_RIGHTS],
+        trust_control_nature_of_control_types: [NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL],
+        owner_of_land_person_nature_of_control_jurisdictions: [NatureOfControlJurisdictionType.SCOTLAND],
+        owner_of_land_other_entity_nature_of_control_jurisdictions: [NatureOfControlJurisdictionType.NORTHERN_IRELAND],
         is_on_sanctions_list: yesNoResponse.No
 
     }


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/UAR-1615

* Added new NOCs to the types
* Updated the mock test data

No mapping logic required as the object and resource use the same type and there is no specific mapping for any NOC fields. Instead several fields including all NOCs are covered by the "..." syntax.