### PR TITLE
Fix/ROE-2636: Straighten out resource mapping discrepancy for `is_secure_register` field

### DIFF
--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -625,8 +625,8 @@ const mapHasSoldLandResource = (option: boolean | undefined): string | undefined
 const mapIsSecureRegister = (option: string | undefined): boolean | undefined => {
     return typeof option === "undefined" ? option : (option !== "0");
 }
-const mapIsSecureRegisterResource = (option: boolean | undefined): string | undefined => {
-    return typeof option === "undefined" ? option : (option ? "1" : "0");
+const mapIsSecureRegisterResource = (option: boolean | undefined | null): string | undefined => {
+    return typeof option !== "boolean" ? undefined : (option ? "1" : "0");
 }
 
 const convertOptionalDateToIsoDateString = (day: string = "", month: string = "", year: string = ""): string => {


### PR DESCRIPTION
Straightens out the sdk resource mapping discrepancy for the `is_secure_register` field