### PR TITLE
Fix/ROE-2636: Straighten out resource mapping discrepancy for boolean fields

### DIFF
--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -618,7 +618,7 @@ const mapIsoDate = (date: string): InputDate => {
 const mapHasSoldLand = (option: string | undefined): boolean | undefined => {
     return typeof option === "undefined" ? option : (option !== "0");
 }
-const mapHasSoldLandResource = (option: boolean | undefined): string | undefined => {
+const mapHasSoldLandResource = (option: boolean | undefined | null): string | undefined => {
     return typeof option !== "boolean" ? undefined : (option ? "1" : "0");
 }
 

--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -619,14 +619,14 @@ const mapHasSoldLand = (option: string | undefined): boolean | undefined => {
     return typeof option === "undefined" ? option : (option !== "0");
 }
 const mapHasSoldLandResource = (option: boolean | undefined): string | undefined => {
-    return typeof option === "undefined" ? option : (option ? "1" : "0");
+    return typeof option !== "boolean" ? undefined : (option ? "1" : "0");
 }
 
 const mapIsSecureRegister = (option: string | undefined): boolean | undefined => {
     return typeof option === "undefined" ? option : (option !== "0");
 }
-const mapIsSecureRegisterResource = (option: boolean | undefined): string | undefined => {
-    return typeof option === "undefined" ? option : (option ? "1" : "0");
+const mapIsSecureRegisterResource = (option: boolean | undefined | null): string | undefined => {
+    return typeof option !== "boolean" ? undefined : (option ? "1" : "0");
 }
 
 const convertOptionalDateToIsoDateString = (day: string = "", month: string = "", year: string = ""): string => {


### PR DESCRIPTION
Straightens out the sdk resource mapping discrepancy for the boolean fields: `has_sold_land` and `is_secure_register`.