### PR TITLE
Added a second acsp DELETE endpoint

### DIFF
--- a/src/services/acsp/service.ts
+++ b/src/services/acsp/service.ts
@@ -79,12 +79,22 @@ export default class {
     }
 
     /**
-     * Delete an existing ACSP application from MongoDB
+     * Delete an existing ACSP application from MongoDB and its corresponding transaction
      * @param transactionId the id of the transaction associated with the application. This will also be deleted.
      * @param acspApplicationId the id of the user whose application will be deleted
      */
-    public async deleteSavedApplication (transactionId: string, acspApplicationId: string): Promise<HttpResponse> {
+    public async deleteSavedApplicationAndTransaction (transactionId: string, acspApplicationId: string): Promise<HttpResponse> {
         const url = `/transactions/${transactionId}/authorised-corporate-service-provider-applications/${acspApplicationId}`;
+        const resp: HttpResponse = await this.client.httpDelete(url);
+        return resp;
+    }
+
+    /**
+     * Delete an existing ACSP application from MongoDB
+     * @param acspApplicationId the id of the user whose application will be deleted
+     */
+    public async deleteSavedApplication (acspApplicationId: string): Promise<HttpResponse> {
+        const url = `/acsp-api/user/${acspApplicationId}/application`;
         const resp: HttpResponse = await this.client.httpDelete(url);
         return resp;
     }

--- a/test/services/acsp/acsp.spec.ts
+++ b/test/services/acsp/acsp.spec.ts
@@ -83,18 +83,34 @@ describe("Acsp Registration PUT", () => {
     });
 });
 
-describe("Acsp Registration DELETE", () => {
+describe("Acsp Registration DELETE applicaiton and transaction", () => {
     it("should return 204 on successful delete", async () => {
         sinon.stub(mockValues.requestClient, "httpDelete").resolves(mockValues.mockDeleteAcsp[204]);
         const ofService: AcspService = new AcspService(mockValues.requestClient);
-        const data = await ofService.deleteSavedApplication(TRANSACTION_ID, SUBMISSION_ID);
+        const data = await ofService.deleteSavedApplicationAndTransaction(TRANSACTION_ID, SUBMISSION_ID);
         expect(data.status).to.equal(204);
     })
 
     it("should return 404 if no application exists", async () => {
         sinon.stub(mockValues.requestClient, "httpDelete").resolves(mockValues.mockDeleteAcsp[404]);
         const ofService: AcspService = new AcspService(mockValues.requestClient);
-        const data = await ofService.deleteSavedApplication(TRANSACTION_ID, SUBMISSION_ID);
+        const data = await ofService.deleteSavedApplicationAndTransaction(TRANSACTION_ID, SUBMISSION_ID);
+        expect(data.status).to.equal(404);
+    })
+})
+
+describe("Acsp Registration DELETE application", () => {
+    it("should return 204 on successful delete", async () => {
+        sinon.stub(mockValues.requestClient, "httpDelete").resolves(mockValues.mockDeleteAcsp[204]);
+        const ofService: AcspService = new AcspService(mockValues.requestClient);
+        const data = await ofService.deleteSavedApplication(TRANSACTION_ID);
+        expect(data.status).to.equal(204);
+    })
+
+    it("should return 404 if no application exists", async () => {
+        sinon.stub(mockValues.requestClient, "httpDelete").resolves(mockValues.mockDeleteAcsp[404]);
+        const ofService: AcspService = new AcspService(mockValues.requestClient);
+        const data = await ofService.deleteSavedApplication(TRANSACTION_ID);
         expect(data.status).to.equal(404);
     })
 })


### PR DESCRIPTION
Added a second ACSP DELETE endpoint, which only deletes the ACSP application not the transaction. This is to be used when transaction status is closed.