### PR TITLE
CC-1673 - Generate coverage when running sonar checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,5 +49,6 @@ endif
 dist: lint test-unit clean package
 
 .PHONY: sonar
-sonar: test
+sonar:
+	npm run coverage:report
 	npm run analyse-code


### PR DESCRIPTION
Should allow coverage to be displayed properly for Sonar checks.