### PR TITLE
LP-312: Limited Partnership Type Enum

### DIFF
--- a/src/services/limited-partnerships/types.ts
+++ b/src/services/limited-partnerships/types.ts
@@ -9,6 +9,7 @@ export interface LimitedPartnership {
     data?: {
         partnership_name?: string;
         name_ending?: NameEndingType;
+        partnership_type?: PartnershipType;
     }
 }
 
@@ -27,4 +28,11 @@ export enum NameEndingType {
     PARTNERIAETH_CYFYNGEDIG = "Partneriaeth Cyfyngedig",
     PC = "PC",
     P_DOT_C_DOT = "P.C."
+}
+
+export enum PartnershipType {
+    LP = "LP",
+    PFLP = "PFLP",
+    SLP = "SLP",
+    SPFLP = "SPFLP"
 }

--- a/test/services/limited-partnerships/limited.partnerships.mock.ts
+++ b/test/services/limited-partnerships/limited.partnerships.mock.ts
@@ -2,7 +2,8 @@ import { RequestClient } from "../../../src";
 import {
     LimitedPartnership,
     LimitedPartnershipCreated,
-    NameEndingType
+    NameEndingType,
+    PartnershipType
 } from "../../../src/services/limited-partnerships";
 
 export const requestClient = new RequestClient({
@@ -13,7 +14,8 @@ export const requestClient = new RequestClient({
 export const LIMITED_PARTNERSHIP_OBJECT_MOCK: LimitedPartnership = {
     data: {
         partnership_name: "Legalised Asset Stashing",
-        name_ending: NameEndingType.LIMITED_PARTNERSHIP
+        name_ending: NameEndingType.LIMITED_PARTNERSHIP,
+        partnership_type: PartnershipType.LP
     }
 };
 

--- a/test/services/limited-partnerships/limited.partnerships.spec.ts
+++ b/test/services/limited-partnerships/limited.partnerships.spec.ts
@@ -42,7 +42,8 @@ describe("LimitedPartnershipsService POST Tests suite", () => {
                     {
                         data: {
                             partnership_name: "Legalised Asset Stashing",
-                            name_ending: "Limited Partnership"
+                            name_ending: "Limited Partnership",
+                            partnership_type: "LP"
                         }
                     }
                 )


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/LP-312

Added the new enum and introduced it as a new data field "partnership_type" in the LimitedPartnership interface.

Added a comment about this here:
https://companieshouse.atlassian.net/wiki/spaces/Arch/pages/4925817463/LP+Data+Model+-+Company+Details
