### PR TITLE
feat/roe-2732: add payment metadata to overseas entity object

### DIFF
--- a/src/services/overseas-entities/mapping.ts
+++ b/src/services/overseas-entities/mapping.ts
@@ -53,7 +53,8 @@ export const mapOverseasEntity = (body: OverseasEntity): OverseasEntityResource 
         is_remove: (body.is_remove) ? body.is_remove : null,
         has_sold_land: mapHasSoldLand(body.has_sold_land),
         is_secure_register: mapIsSecureRegister(body.is_secure_register),
-        who_is_registering: body.who_is_registering
+        who_is_registering: body.who_is_registering,
+        payment: body.payment ? body.payment : null
     };
 };
 
@@ -83,7 +84,8 @@ export const mapOverseasEntityResource = (body: OverseasEntityResource): Oversea
         is_remove: body.is_remove,
         has_sold_land: mapHasSoldLandResource(body.has_sold_land),
         is_secure_register: mapIsSecureRegisterResource(body.is_secure_register),
-        who_is_registering: body.who_is_registering
+        who_is_registering: body.who_is_registering,
+        payment: body.payment ? body.payment : null
     };
 };
 

--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -1,6 +1,7 @@
 /**
  * Overseas Entity interface used within this SDK
  */
+import { CreatePaymentRequest, CreatePaymentRequestResource } from "../payment";
 
 export interface OverseasEntity {
     entity_name?: string;
@@ -22,6 +23,7 @@ export interface OverseasEntity {
     has_sold_land?: string;
     is_secure_register?: string;
     who_is_registering?: string;
+    payment?: CreatePaymentRequest;
 }
 
 export interface OverseasEntityResource {
@@ -44,6 +46,7 @@ export interface OverseasEntityResource {
     has_sold_land?: boolean;
     is_secure_register?: boolean;
     who_is_registering?: string;
+    payment?: CreatePaymentRequest;
 }
 
 export interface OverseasEntityExtraDetails {

--- a/src/services/overseas-entities/types.ts
+++ b/src/services/overseas-entities/types.ts
@@ -1,7 +1,7 @@
 /**
  * Overseas Entity interface used within this SDK
  */
-import { CreatePaymentRequest, CreatePaymentRequestResource } from "../payment";
+import { CreatePaymentRequest } from "../payment";
 
 export interface OverseasEntity {
     entity_name?: string;

--- a/test/services/overseas-entities/overseas.entities.mock.ts
+++ b/test/services/overseas-entities/overseas.entities.mock.ts
@@ -1,4 +1,6 @@
 import { RequestClient } from "../../../src";
+import { CreatePaymentRequest } from "../../../src/services/payment/types"
+import { mockAddress1 } from "../officer-filing/officer.filing.mock";
 import {
     Address,
     BeneficialOwnerCorporate,
@@ -43,9 +45,8 @@ import {
     RemoveResource,
     ChangeBoRelevantPeriodType,
     TrusteeInvolvedRelevantPeriodType,
-    ChangeBeneficiaryRelevantPeriodType
+    ChangeBeneficiaryRelevantPeriodType,
 } from "../../../src/services/overseas-entities";
-import { mockAddress1 } from "../officer-filing/officer.filing.mock";
 
 export const ADDRESS: Address = {
     property_name_number: "property name 1",
@@ -102,6 +103,13 @@ export const ENTITY_NUMBER_MOCK = "Entity Number";
 export const PRESENTER_OBJECT_MOCK: Presenter = {
     full_name: "Full Name",
     email: "user@domain.roe"
+};
+
+export const PAYMENT_OBJECT_MOCK: CreatePaymentRequest = {
+    resource: "http://api.base-domain/transactions/abc123/payment",
+    state: "9a82902b-5292-4908-9898-14212b7ee1d5",
+    redirectUri: "http://base-domain/service-name/transaction/abc1234/submission/xyz890/payment",
+    reference: "ServiceNameReference_058235-235017-353205"
 };
 
 export enum ENTITY_WHO_IS_REGISTERING {
@@ -537,7 +545,8 @@ export const OVERSEAS_ENTITY_OBJECT_MOCK: OverseasEntity = {
     is_remove: undefined,
     has_sold_land: undefined,
     is_secure_register: undefined,
-    who_is_registering: undefined
+    who_is_registering: undefined,
+    payment: PAYMENT_OBJECT_MOCK
 };
 
 export const OVERSEAS_ENTITY_EXTRA_DETAILS_OBJECT_MOCK: OverseasEntityExtraDetails = {
@@ -701,7 +710,8 @@ export const OVERSEAS_ENTITY_RESOURCE_OBJECT_MOCK: OverseasEntityResource = {
     managing_officers_corporate: MANAGING_OFFICERS_CORPORATE_RESOURCE_MOCK_LIST,
     trusts: TRUSTS_RESOURCE_MOCK,
     update: UPDATE_RESOURCE_MOCK,
-    remove: REMOVE_RESOURCE_MOCK
+    remove: REMOVE_RESOURCE_MOCK,
+    payment: PAYMENT_OBJECT_MOCK
 };
 
 export const OVERSEAS_ENTITY_EXTRA_DETAILS_RESOURCE_MOCK: OverseasEntityExtraDetails = {

--- a/test/services/overseas-entities/overseas.entities.mock.ts
+++ b/test/services/overseas-entities/overseas.entities.mock.ts
@@ -45,7 +45,7 @@ import {
     RemoveResource,
     ChangeBoRelevantPeriodType,
     TrusteeInvolvedRelevantPeriodType,
-    ChangeBeneficiaryRelevantPeriodType,
+    ChangeBeneficiaryRelevantPeriodType
 } from "../../../src/services/overseas-entities";
 
 export const ADDRESS: Address = {

--- a/test/services/overseas-entities/overseas.entities.spec.ts
+++ b/test/services/overseas-entities/overseas.entities.spec.ts
@@ -3,6 +3,17 @@ import { expect } from "chai";
 import sinon from "sinon";
 
 import * as mockValues from "./overseas.entities.mock";
+import Mapping from "../../../src/mapping/mapping";
+import { ENTITY_WHO_IS_REGISTERING, PAYMENT_OBJECT_MOCK } from "./overseas.entities.mock";
+
+import Resource, { ApiErrorResponse } from "../../../src/services/resource";
+
+import {
+    mapOverseasEntity,
+    mapOverseasEntityResource,
+    mapOverseasEntityExtraDetails
+} from "../../../src/services/overseas-entities/mapping";
+
 import {
     BeneficialOwnersStatementType,
     OverseasEntityCreated,
@@ -20,12 +31,9 @@ import {
     TrustCorporate,
     TrustCorporateResource
 } from "../../../src/services/overseas-entities";
-import Resource, { ApiErrorResponse } from "../../../src/services/resource";
-import { mapOverseasEntity, mapOverseasEntityResource, mapOverseasEntityExtraDetails } from "../../../src/services/overseas-entities/mapping";
-import Mapping from "../../../src/mapping/mapping";
-import { ENTITY_WHO_IS_REGISTERING } from "./overseas.entities.mock";
 
 describe("OverseasEntityService POST Tests suite", () => {
+
     beforeEach(() => {
         sinon.reset();
         sinon.restore();
@@ -71,6 +79,7 @@ describe("OverseasEntityService POST Tests suite", () => {
 });
 
 describe("OverseasEntityService PUT Tests suite", () => {
+
     beforeEach(() => {
         sinon.reset();
         sinon.restore();
@@ -104,6 +113,7 @@ describe("OverseasEntityService PUT Tests suite", () => {
 });
 
 describe("OverseasEntityService GET Tests suite", () => {
+
     beforeEach(() => {
         sinon.reset();
         sinon.restore();
@@ -200,6 +210,7 @@ describe("OverseasEntityService GET Tests suite", () => {
 });
 
 describe("Mapping OverseasEntity Tests suite", () => {
+
     it("should return OverseasEntityResource object from mapOverseasEntity method", async () => {
         const data = mapOverseasEntity({
             entity_name: mockValues.ENTITY_NAME_FIELD_MOCK,
@@ -220,7 +231,8 @@ describe("Mapping OverseasEntity Tests suite", () => {
             is_remove: true,
             has_sold_land: "0",
             is_secure_register: "0",
-            who_is_registering: "agent"
+            who_is_registering: "agent",
+            payment: mockValues.PAYMENT_OBJECT_MOCK
         });
 
         expect(data.entity_name).to.deep.equal(mockValues.OVERSEAS_ENTITY_RESOURCE_OBJECT_MOCK.entity_name);
@@ -243,6 +255,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
         expect(data.is_secure_register).to.deep.equal(false);
         expect(data.who_is_registering).to.deep.equal(ENTITY_WHO_IS_REGISTERING.AGENT);
         expect(data.remove).to.deep.equal(mockValues.OVERSEAS_ENTITY_RESOURCE_OBJECT_MOCK.remove);
+        expect(data.payment).to.deep.equal(mockValues.PAYMENT_OBJECT_MOCK);
     });
 
     it("should return OverseasEntityResource object from mapOverseasEntity method", async () => {
@@ -310,7 +323,8 @@ describe("Mapping OverseasEntity Tests suite", () => {
             is_remove: undefined,
             has_sold_land: undefined,
             is_secure_register: undefined,
-            who_is_registering: undefined
+            who_is_registering: undefined,
+            payment: undefined
         });
         expect(data.entity_name).to.deep.equal(null);
         expect(data.entity_number).to.deep.equal(null);
@@ -331,6 +345,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
         expect(data.has_sold_land).to.deep.equal(undefined);
         expect(data.is_secure_register).to.deep.equal(undefined);
         expect(data.who_is_registering).to.deep.equal(undefined);
+        expect(data.payment).to.deep.equal(null);
     });
 
     it("should return OverseasEntity object from mapOverseasEntityResource method", async () => {
@@ -354,7 +369,8 @@ describe("Mapping OverseasEntity Tests suite", () => {
             is_remove: true,
             has_sold_land: true,
             is_secure_register: true,
-            who_is_registering: ENTITY_WHO_IS_REGISTERING.AGENT
+            who_is_registering: ENTITY_WHO_IS_REGISTERING.AGENT,
+            payment: OE_RESOURCE.payment
         });
 
         expect(data.entity_name).to.deep.equal(mockValues.ENTITY_NAME_FIELD_MOCK);
@@ -377,6 +393,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
         expect(data.has_sold_land).to.deep.equal("1");
         expect(data.is_secure_register).to.deep.equal("1");
         expect(data.who_is_registering).to.deep.equal("agent");
+        expect(data.payment).to.deep.equal(mockValues.PAYMENT_OBJECT_MOCK);
     });
 
     it("should return OverseasEntity object from mapOverseasEntityResource method", async () => {
@@ -443,7 +460,8 @@ describe("Mapping OverseasEntity Tests suite", () => {
             is_remove: undefined,
             has_sold_land: undefined,
             is_secure_register: undefined,
-            who_is_registering: undefined
+            who_is_registering: undefined,
+            payment: undefined
         });
 
         expect(data.entity_name).to.deep.equal(mockValues.ENTITY_NAME_FIELD_MOCK);
@@ -462,7 +480,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
         expect(data.is_remove).to.deep.equal(undefined);
         expect(data.has_sold_land).to.deep.equal(undefined);
         expect(data.is_secure_register).to.deep.equal(undefined);
-        expect(data.who_is_registering).to.deep.equal(undefined);
+        expect(data.payment).to.deep.equal(null);
     });
 
     it("should return OverseasEntity object from mapOverseasEntityResource method with just entity number data", async () => {
@@ -483,7 +501,8 @@ describe("Mapping OverseasEntity Tests suite", () => {
             is_remove: undefined,
             has_sold_land: undefined,
             is_secure_register: undefined,
-            who_is_registering: undefined
+            who_is_registering: undefined,
+            payment: undefined
         });
 
         expect(data.entity_name).to.deep.equal(null);
@@ -503,6 +522,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
         expect(data.has_sold_land).to.deep.equal(undefined);
         expect(data.is_secure_register).to.deep.equal(undefined);
         expect(data.who_is_registering).to.deep.equal(undefined);
+        expect(data.payment).to.deep.equal(null);
     });
 
     it("should return OverseasEntity object from mapOverseasEntityResource method with just Presenter data", async () => {
@@ -522,7 +542,8 @@ describe("Mapping OverseasEntity Tests suite", () => {
             is_remove: undefined,
             has_sold_land: undefined,
             is_secure_register: undefined,
-            who_is_registering: undefined
+            who_is_registering: undefined,
+            payment: undefined
         });
 
         expect(data.entity_name).to.deep.equal(null);
@@ -541,6 +562,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
         expect(data.has_sold_land).to.deep.equal(undefined);
         expect(data.is_secure_register).to.deep.equal(undefined);
         expect(data.who_is_registering).to.deep.equal(undefined);
+        expect(data.payment).to.deep.equal(null);
     });
 
     it("should return OverseasEntity object from mapOverseasEntityResource method with just Update data", async () => {
@@ -562,7 +584,8 @@ describe("Mapping OverseasEntity Tests suite", () => {
             is_remove: undefined,
             has_sold_land: undefined,
             is_secure_register: undefined,
-            who_is_registering: undefined
+            who_is_registering: undefined,
+            payment: undefined
         });
 
         expect(data.entity_name).to.deep.equal(null);
@@ -583,6 +606,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
         expect(data.has_sold_land).to.deep.equal(undefined);
         expect(data.is_secure_register).to.deep.equal(undefined);
         expect(data.who_is_registering).to.deep.equal(undefined);
+        expect(data.payment).to.deep.equal(null);
     });
 
     it("should return OverseasEntity object from mapOverseasEntityResource method with just Remove data", async () => {
@@ -604,7 +628,8 @@ describe("Mapping OverseasEntity Tests suite", () => {
             is_remove: undefined,
             has_sold_land: undefined,
             is_secure_register: undefined,
-            who_is_registering: undefined
+            who_is_registering: undefined,
+            payment: undefined
         });
 
         expect(data.entity_name).to.deep.equal(null);
@@ -625,6 +650,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
         expect(data.has_sold_land).to.deep.equal(undefined);
         expect(data.is_secure_register).to.deep.equal(undefined);
         expect(data.who_is_registering).to.deep.equal(undefined);
+        expect(data.payment).to.deep.equal(null);
     });
 
     it("should return OverseasEntity object from mapOverseasEntityResource method with mapped Update dates", async () => {
@@ -646,7 +672,8 @@ describe("Mapping OverseasEntity Tests suite", () => {
             is_remove: undefined,
             has_sold_land: undefined,
             is_secure_register: undefined,
-            who_is_registering: undefined
+            who_is_registering: undefined,
+            payment: undefined
         });
 
         expect(data.update).to.deep.equal(mockValues.UPDATE_OBJECT_MOCK);
@@ -676,7 +703,8 @@ describe("Mapping OverseasEntity Tests suite", () => {
             is_remove: undefined,
             has_sold_land: undefined,
             is_secure_register: undefined,
-            who_is_registering: undefined
+            who_is_registering: undefined,
+            payment: undefined
         });
 
         expect(data.update?.filing_date).to.undefined;
@@ -706,7 +734,8 @@ describe("Mapping OverseasEntity Tests suite", () => {
             is_remove: undefined,
             has_sold_land: undefined,
             is_secure_register: undefined,
-            who_is_registering: undefined
+            who_is_registering: undefined,
+            payment: undefined
         });
 
         expect(data.update?.date_of_creation).to.undefined;
@@ -944,6 +973,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
     });
 
     describe("OverseasEntityService getManagingOfficersPrivateData Tests suite", () => {
+
         beforeEach(() => {
             sinon.reset();
             sinon.restore();
@@ -983,6 +1013,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
     });
 
     describe("OverseasEntityService getTrustsPrivateData Tests suite", () => {
+
         beforeEach(() => {
             sinon.reset();
             sinon.restore();
@@ -1038,6 +1069,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
     });
 
     describe("OverseasEntityService getTrustLinksPrivateData Tests suite", () => {
+
         beforeEach(() => {
             sinon.reset();
             sinon.restore();
@@ -1077,6 +1109,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
     });
 
     describe("OverseasEntityService getIndividualTrusteesPrivateData Tests suite", () => {
+
         beforeEach(() => {
             sinon.reset();
             sinon.restore();
@@ -1118,6 +1151,7 @@ describe("Mapping OverseasEntity Tests suite", () => {
     });
 
     describe("OverseasEntityService getCorporateTrusteesPrivateData Tests suite", () => {
+
         beforeEach(() => {
             sinon.reset();
             sinon.restore();

--- a/test/services/overseas-entities/overseas.entities.spec.ts
+++ b/test/services/overseas-entities/overseas.entities.spec.ts
@@ -33,7 +33,6 @@ import {
 } from "../../../src/services/overseas-entities";
 
 describe("OverseasEntityService POST Tests suite", () => {
-
     beforeEach(() => {
         sinon.reset();
         sinon.restore();
@@ -79,7 +78,6 @@ describe("OverseasEntityService POST Tests suite", () => {
 });
 
 describe("OverseasEntityService PUT Tests suite", () => {
-
     beforeEach(() => {
         sinon.reset();
         sinon.restore();
@@ -113,7 +111,6 @@ describe("OverseasEntityService PUT Tests suite", () => {
 });
 
 describe("OverseasEntityService GET Tests suite", () => {
-
     beforeEach(() => {
         sinon.reset();
         sinon.restore();
@@ -210,7 +207,6 @@ describe("OverseasEntityService GET Tests suite", () => {
 });
 
 describe("Mapping OverseasEntity Tests suite", () => {
-
     it("should return OverseasEntityResource object from mapOverseasEntity method", async () => {
         const data = mapOverseasEntity({
             entity_name: mockValues.ENTITY_NAME_FIELD_MOCK,
@@ -973,7 +969,6 @@ describe("Mapping OverseasEntity Tests suite", () => {
     });
 
     describe("OverseasEntityService getManagingOfficersPrivateData Tests suite", () => {
-
         beforeEach(() => {
             sinon.reset();
             sinon.restore();
@@ -1013,7 +1008,6 @@ describe("Mapping OverseasEntity Tests suite", () => {
     });
 
     describe("OverseasEntityService getTrustsPrivateData Tests suite", () => {
-
         beforeEach(() => {
             sinon.reset();
             sinon.restore();
@@ -1069,7 +1063,6 @@ describe("Mapping OverseasEntity Tests suite", () => {
     });
 
     describe("OverseasEntityService getTrustLinksPrivateData Tests suite", () => {
-
         beforeEach(() => {
             sinon.reset();
             sinon.restore();
@@ -1109,7 +1102,6 @@ describe("Mapping OverseasEntity Tests suite", () => {
     });
 
     describe("OverseasEntityService getIndividualTrusteesPrivateData Tests suite", () => {
-
         beforeEach(() => {
             sinon.reset();
             sinon.restore();
@@ -1151,7 +1143,6 @@ describe("Mapping OverseasEntity Tests suite", () => {
     });
 
     describe("OverseasEntityService getCorporateTrusteesPrivateData Tests suite", () => {
-
         beforeEach(() => {
             sinon.reset();
             sinon.restore();


### PR DESCRIPTION
Adds payment metadata to overseas entity object