### PR TITLE
Updating sendIdentityVerificationEmail method sig to accept app type query param

### DIFF
--- a/src/services/acsp/service.ts
+++ b/src/services/acsp/service.ts
@@ -90,8 +90,18 @@ export default class {
         return resp;
     }
 
-    public async sendIdentityVerificationEmail (emailData: ClientVerificationEmail): Promise<HttpResponse> {
-        const url = `/acsp-api/verify-client-identity/send-identity-verification-email`;
+    /**
+     * Send an identity verification email to verify or reverify a client identity web app.
+     * @param emailData the email data containing verification details
+     * @param queryParams optional query parameters
+     * @param queryParams.application_type optional application type to filter the verification or reverification services.
+     * @returns Promise that resolves to the HTTP response from the API
+     */
+    public async sendIdentityVerificationEmail (emailData: ClientVerificationEmail, queryParams?: { application_type?: string }): Promise<HttpResponse> {
+        let url = `/acsp-api/verify-client-identity/send-identity-verification-email`;
+        if (queryParams?.application_type) {
+            url += `?application_type=${queryParams.application_type}`;
+        }
         return this.client.httpPost(url, emailData);
     }
 }

--- a/test/services/acsp/acsp.spec.ts
+++ b/test/services/acsp/acsp.spec.ts
@@ -103,13 +103,78 @@ describe("ACSP Verifiy a client send confirmation email", async () => {
     it("should return 200 on successful email send", async () => {
         sinon.stub(mockValues.requestClient, "httpPost").resolves(mockValues.mockSendEmail[200]);
         const ofService: AcspService = new AcspService(mockValues.requestClient);
-        const data = await ofService.sendIdentityVerificationEmail(mockValues.mockClientVerificationEmail);
+        const data = await ofService.sendIdentityVerificationEmail(mockValues.mockClientVerificationEmail, { application_type: "verification" });
         expect(data.status).to.equal(200);
     })
+
     it("should return 500 if email fails", async () => {
         sinon.stub(mockValues.requestClient, "httpPost").resolves(mockValues.mockSendEmail[500]);
         const ofService: AcspService = new AcspService(mockValues.requestClient);
-        const data = await ofService.sendIdentityVerificationEmail(mockValues.mockClientVerificationEmail);
+        const data = await ofService.sendIdentityVerificationEmail(mockValues.mockClientVerificationEmail, { application_type: "verification" });
         expect(data.status).to.equal(500);
     })
-})
+
+    it("should call correct URL with verification query parameter", async () => {
+        const httpPostStub = sinon.stub(mockValues.requestClient, "httpPost").resolves(mockValues.mockSendEmail[200]);
+        const ofService: AcspService = new AcspService(mockValues.requestClient);
+
+        await ofService.sendIdentityVerificationEmail(
+            mockValues.mockClientVerificationEmail,
+            { application_type: "verification" }
+        );
+
+        expect(httpPostStub.calledWith(
+            "/acsp-api/verify-client-identity/send-identity-verification-email?application_type=verification",
+            mockValues.mockClientVerificationEmail
+        )).to.be.true;
+    })
+
+    it("should call URL without query parameter when application_type is not provided", async () => {
+        const httpPostStub = sinon.stub(mockValues.requestClient, "httpPost").resolves(mockValues.mockSendEmail[200]);
+        const ofService: AcspService = new AcspService(mockValues.requestClient);
+
+        await ofService.sendIdentityVerificationEmail(mockValues.mockClientVerificationEmail);
+
+        expect(httpPostStub.calledWith(
+            "/acsp-api/verify-client-identity/send-identity-verification-email",
+            mockValues.mockClientVerificationEmail
+        )).to.be.true;
+    })
+});
+
+describe("ACSP Reverify a client send confirmation email", async () => {
+    it("should return 200 on successful reverification email send", async () => {
+        sinon.stub(mockValues.requestClient, "httpPost").resolves(mockValues.mockSendEmail[200]);
+        const ofService: AcspService = new AcspService(mockValues.requestClient);
+        const data = await ofService.sendIdentityVerificationEmail(
+            mockValues.mockClientVerificationEmail,
+            { application_type: "reverification" }
+        );
+        expect(data.status).to.equal(200);
+    })
+
+    it("should return 500 if reverification email fails", async () => {
+        sinon.stub(mockValues.requestClient, "httpPost").resolves(mockValues.mockSendEmail[500]);
+        const ofService: AcspService = new AcspService(mockValues.requestClient);
+        const data = await ofService.sendIdentityVerificationEmail(
+            mockValues.mockClientVerificationEmail,
+            { application_type: "reverification" }
+        );
+        expect(data.status).to.equal(500);
+    })
+
+    it("should call correct URL with reverification query parameter", async () => {
+        const httpPostStub = sinon.stub(mockValues.requestClient, "httpPost").resolves(mockValues.mockSendEmail[200]);
+        const ofService: AcspService = new AcspService(mockValues.requestClient);
+
+        await ofService.sendIdentityVerificationEmail(
+            mockValues.mockClientVerificationEmail,
+            { application_type: "reverification" }
+        );
+
+        expect(httpPostStub.calledWith(
+            "/acsp-api/verify-client-identity/send-identity-verification-email?application_type=reverification",
+            mockValues.mockClientVerificationEmail
+        )).to.be.true;
+    })
+});


### PR DESCRIPTION
Changes required as part of ticket:
[IDVA5-2643](https://companieshouse.atlassian.net/browse/IDVA5-2643)

- As we now call the sendIdentityVerificationEmail method within both Verify and Reverify a clients ID service to send confirmation emails upon application completion, we need to have a way to distinguish which application type is sending the emails.
- Added an optional query param to the method signature, which is used to determine if the request is coming from "verification" or "reverification" service

[IDVA5-2643]: https://companieshouse.atlassian.net/browse/IDVA5-2643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ