### PR TITLE
LP-1740 Add psc delete endpoint and rename existing psc calls

### DIFF
--- a/src/services/limited-partnerships/service.ts
+++ b/src/services/limited-partnerships/service.ts
@@ -227,10 +227,10 @@ export default class LimitedPartnershipsService {
     }
 
     /*
-    * Calls to psc endpoints
+    * Calls to person with significant control endpoints
     */
 
-    public async postPsc (
+    public async postPersonWithSignificantControl (
         transactionId: string,
         body: PersonWithSignificantControl
     ): Promise<Resource<LimitedPartnershipResourceCreated> | ApiErrorResponse> {
@@ -243,11 +243,11 @@ export default class LimitedPartnershipsService {
         };
     }
 
-    public async getPsc (
+    public async getPersonWithSignificantControl (
         transactionId: string,
-        pscId: string
+        personWithSignificantControlId: string
     ): Promise<Resource<PersonWithSignificantControl> | ApiErrorResponse> {
-        const URL = `/transactions/${transactionId}/limited-partnership/person-with-significant-control/${pscId}`;
+        const URL = `/transactions/${transactionId}/limited-partnership/person-with-significant-control/${personWithSignificantControlId}`;
         const response: HttpResponse = await this.client.httpGet(URL);
 
         return {
@@ -256,13 +256,26 @@ export default class LimitedPartnershipsService {
         };
     }
 
-    public async patchPsc (
+    public async patchPersonWithSignificantControl (
         transactionId: string,
-        pscId: string,
+        personWithSignificantControlId: string,
         body: PersonWithSignificantControl["data"]
     ): Promise<Resource<void> | ApiErrorResponse> {
-        const URL = `/transactions/${transactionId}/limited-partnership/person-with-significant-control/${pscId}`;
+        const URL = `/transactions/${transactionId}/limited-partnership/person-with-significant-control/${personWithSignificantControlId}`;
         const response: HttpResponse = await this.client.httpPatch(URL, body);
+
+        return {
+            httpStatusCode: response.status,
+            resource: { ...response.body }
+        };
+    }
+
+    public async deletePersonWithSignificantControl (
+        transactionId: string,
+        personWithSignificantControlId: string
+    ): Promise<Resource<void> | ApiErrorResponse> {
+        const URL = `/transactions/${transactionId}/limited-partnership/person-with-significant-control/${personWithSignificantControlId}`;
+        const response: HttpResponse = await this.client.httpDelete(URL);
 
         return {
             httpStatusCode: response.status,

--- a/test/services/limited-partnerships/limited.partnerships.mock.ts
+++ b/test/services/limited-partnerships/limited.partnerships.mock.ts
@@ -155,7 +155,7 @@ export const LIMITED_PARTNER_OBJECT_MOCK: LimitedPartner = {
     }
 };
 
-export const PSC_OBJECT_MOCK: PersonWithSignificantControl = {
+export const PERSON_WITH_SIGNIFICANT_CONTROL_OBJECT_MOCK: PersonWithSignificantControl = {
     id: "123456",
     data: {
         date_effective_from: "2005-02-04",
@@ -239,7 +239,7 @@ export const SUBMISSION_ID = "09876";
 export const LIMITED_PARTNERSHIP_ID = "00112233";
 export const GENERAL_PARTNER_ID = "00112233";
 export const LIMITED_PARTNER_ID = "11223344";
-export const PSC_ID = "22334455";
+export const PERSON_WITH_SIGNIFICANT_CONTROL_ID = "22334455";
 export const FILE_RESOURCE_ID = "a1b2c3";
 export const UNAUTHORISED = "Unauthorised";
 export const BAD_REQUEST = "Bad Request";
@@ -342,20 +342,26 @@ export const mockDeleteLimitedPartnerResponse = {
     401: { status: 401, body: { error: UNAUTHORISED } }
 };
 
-export const mockPostPscResponse = {
+export const mockPostPersonWithSignificantControlResponse = {
     201: { status: 201, body: mockLimitedPartnershipCreatedResource },
     400: { status: 400, body: { error: BAD_REQUEST } },
     401: { status: 401, body: { error: UNAUTHORISED } }
 };
 
-export const mockGetPscResponse = {
-    200: { status: 200, body: PSC_OBJECT_MOCK },
+export const mockGetPersonWithSignificantControlResponse = {
+    200: { status: 200, body: PERSON_WITH_SIGNIFICANT_CONTROL_OBJECT_MOCK },
     404: { status: 404, body: { error: NOT_FOUND } },
     401: { status: 401, body: { error: UNAUTHORISED } }
 };
 
-export const mockPatchPscResponse = {
+export const mockPatchPersonWithSignificantControlResponse = {
     200: { status: 200 },
     400: { status: 400, body: { error: BAD_REQUEST } },
+    401: { status: 401, body: { error: UNAUTHORISED } }
+};
+
+export const mockDeletePersonWithSignificantControlResponse = {
+    204: { status: 204 },
+    404: { status: 404, body: { error: NOT_FOUND } },
     401: { status: 401, body: { error: UNAUTHORISED } }
 };

--- a/test/services/limited-partnerships/limited.partnerships.spec.ts
+++ b/test/services/limited-partnerships/limited.partnerships.spec.ts
@@ -905,25 +905,25 @@ describe("LimitedPartnershipsService", () => {
         })
     });
 
-    describe("Psc", () => {
-        describe("postPsc", () => {
-            it("should return object Id for postPsc method", async () => {
+    describe("PersonWithSignificantControl", () => {
+        describe("postPersonWithSignificantControl", () => {
+            it("should return object Id for postPersonWithSignificantControl method", async () => {
                 const mockRequest = sinon
                     .stub(mockValues.requestClient, "httpPost")
-                    .resolves(mockValues.mockPostPscResponse[201]);
+                    .resolves(mockValues.mockPostPersonWithSignificantControlResponse[201]);
                 const service = new LimitedPartnershipsService(
                     mockValues.requestClient
                 );
-                const response = (await service.postPsc(
+                const response = (await service.postPersonWithSignificantControl(
                     mockValues.TRANSACTION_ID,
-                    mockValues.PSC_OBJECT_MOCK
+                    mockValues.PERSON_WITH_SIGNIFICANT_CONTROL_OBJECT_MOCK
                 )) as Resource<LimitedPartnershipResourceCreated>;
 
                 expect(mockRequest).to.have.been.calledOnce;
                 expect(
                     mockRequest.calledWith(
                         "/transactions/12345/limited-partnership/person-with-significant-control",
-                        mockValues.PSC_OBJECT_MOCK
+                        mockValues.PERSON_WITH_SIGNIFICANT_CONTROL_OBJECT_MOCK
                     )
                 ).to.be.true;
 
@@ -936,11 +936,11 @@ describe("LimitedPartnershipsService", () => {
             it("should return error 400 (Bad Request)", async () => {
                 const mockRequest = sinon
                     .stub(mockValues.requestClient, "httpPost")
-                    .resolves(mockValues.mockPostPscResponse[400]);
+                    .resolves(mockValues.mockPostPersonWithSignificantControlResponse[400]);
                 const service = new LimitedPartnershipsService(
                     mockValues.requestClient
                 );
-                const response = (await service.postPsc(
+                const response = (await service.postPersonWithSignificantControl(
                     mockValues.TRANSACTION_ID,
                     {}
                 )) as Resource<LimitedPartnershipResourceCreated>;
@@ -957,19 +957,19 @@ describe("LimitedPartnershipsService", () => {
             });
         });
 
-        describe("getPsc", () => {
-            it("should return a status 200 and the psc object", async () => {
+        describe("getPersonWithSignificantControl", () => {
+            it("should return a status 200 and the person with significant control object", async () => {
                 const mockRequest = sinon
                     .stub(mockValues.requestClient, "httpGet")
-                    .resolves(mockValues.mockGetPscResponse[200]);
+                    .resolves(mockValues.mockGetPersonWithSignificantControlResponse[200]);
 
                 const service = new LimitedPartnershipsService(
                     mockValues.requestClient
                 );
 
-                const response = await service.getPsc(
+                const response = await service.getPersonWithSignificantControl(
                     mockValues.TRANSACTION_ID,
-                    mockValues.PSC_ID
+                    mockValues.PERSON_WITH_SIGNIFICANT_CONTROL_ID
                 ) as Resource<PersonWithSignificantControl>;
 
                 expect(mockRequest).to.have.been.calledOnce;
@@ -979,20 +979,20 @@ describe("LimitedPartnershipsService", () => {
                     )
                 ).to.be.true;
                 expect(response.httpStatusCode).to.equal(200);
-                expect(response?.resource).to.eql(mockValues.PSC_OBJECT_MOCK);
+                expect(response?.resource).to.eql(mockValues.PERSON_WITH_SIGNIFICANT_CONTROL_OBJECT_MOCK);
             });
 
             it("should return error 401 (Unauthorised)", async () => {
                 const mockRequest = sinon
                     .stub(mockValues.requestClient, "httpGet")
-                    .resolves(mockValues.mockGetPscResponse[401]);
+                    .resolves(mockValues.mockGetPersonWithSignificantControlResponse[401]);
 
                 const service = new LimitedPartnershipsService(
                     mockValues.requestClient
                 );
-                const response = (await service.getPsc(
+                const response = (await service.getPersonWithSignificantControl(
                     mockValues.TRANSACTION_ID,
-                    mockValues.PSC_ID
+                    mockValues.PERSON_WITH_SIGNIFICANT_CONTROL_ID
                 )) as Resource<any>;
 
                 expect(mockRequest).to.have.been.calledOnce;
@@ -1009,12 +1009,12 @@ describe("LimitedPartnershipsService", () => {
             it("should return error 404 (Not Found)", async () => {
                 const mockRequest = sinon
                     .stub(mockValues.requestClient, "httpGet")
-                    .resolves(mockValues.mockGetPscResponse[404]);
+                    .resolves(mockValues.mockGetPersonWithSignificantControlResponse[404]);
 
                 const service = new LimitedPartnershipsService(
                     mockValues.requestClient
                 );
-                const response = (await service.getPsc(
+                const response = (await service.getPersonWithSignificantControl(
                     mockValues.TRANSACTION_ID,
                     "wrong-id"
                 )) as Resource<any>;
@@ -1031,25 +1031,25 @@ describe("LimitedPartnershipsService", () => {
             });
         })
 
-        describe("patchPsc", () => {
-            it("should return 200 patchPsc method", async () => {
+        describe("patchPersonWithSignificantControl", () => {
+            it("should return 200 patchPersonWithSignificantControl method", async () => {
                 const mockRequest = sinon
                     .stub(mockValues.requestClient, "httpPatch")
-                    .resolves(mockValues.mockPatchPscResponse[200]);
+                    .resolves(mockValues.mockPatchPersonWithSignificantControlResponse[200]);
                 const service = new LimitedPartnershipsService(
                     mockValues.requestClient
                 );
-                const response = (await service.patchPsc(
+                const response = (await service.patchPersonWithSignificantControl(
                     mockValues.TRANSACTION_ID,
-                    mockValues.PSC_ID,
-                    mockValues.PSC_OBJECT_MOCK.data
+                    mockValues.PERSON_WITH_SIGNIFICANT_CONTROL_ID,
+                    mockValues.PERSON_WITH_SIGNIFICANT_CONTROL_OBJECT_MOCK.data
                 )) as Resource<void>;
 
                 expect(mockRequest).to.have.been.calledOnce;
                 expect(
                     mockRequest.calledWith(
                         "/transactions/12345/limited-partnership/person-with-significant-control/22334455",
-                        mockValues.PSC_OBJECT_MOCK.data
+                        mockValues.PERSON_WITH_SIGNIFICANT_CONTROL_OBJECT_MOCK.data
                     )
                 ).to.be.true;
 
@@ -1059,13 +1059,13 @@ describe("LimitedPartnershipsService", () => {
             it("should return error 400 (Bad Request)", async () => {
                 const mockRequest = sinon
                     .stub(mockValues.requestClient, "httpPatch")
-                    .resolves(mockValues.mockPatchPscResponse[400]);
+                    .resolves(mockValues.mockPatchPersonWithSignificantControlResponse[400]);
                 const service = new LimitedPartnershipsService(
                     mockValues.requestClient
                 );
-                const response = (await service.patchPsc(
+                const response = (await service.patchPersonWithSignificantControl(
                     mockValues.TRANSACTION_ID,
-                    mockValues.PSC_ID,
+                    mockValues.PERSON_WITH_SIGNIFICANT_CONTROL_ID,
                     {}
                 )) as Resource<LimitedPartnershipResourceCreated>;
 
@@ -1078,6 +1078,30 @@ describe("LimitedPartnershipsService", () => {
                 ).to.be.true;
 
                 expect(response.httpStatusCode).to.equal(400);
+            });
+        })
+
+        describe("deletePersonWithSignificantControl", () => {
+            it("should return 204 deletePersonWithSignificantControl method", async () => {
+                const mockRequest = sinon
+                    .stub(mockValues.requestClient, "httpDelete")
+                    .resolves(mockValues.mockDeletePersonWithSignificantControlResponse[204]);
+                const service = new LimitedPartnershipsService(
+                    mockValues.requestClient
+                );
+                const response = (await service.deletePersonWithSignificantControl(
+                    mockValues.TRANSACTION_ID,
+                    mockValues.PERSON_WITH_SIGNIFICANT_CONTROL_ID
+                )) as Resource<void>;
+
+                expect(mockRequest).to.have.been.calledOnce;
+                expect(
+                    mockRequest.calledWith(
+                        "/transactions/12345/limited-partnership/person-with-significant-control/22334455"
+                    )
+                ).to.be.true;
+
+                expect(response.httpStatusCode).to.equal(204);
             });
         })
     });


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/LP-1740

Adding new delete psc endpoint for limited-partnerships service

Renamed existing psc endpoints to match the api naming (psc -> personWithSignificantControl)