### PR TITLE
fix incorrectly named query parameter

### DIFF
--- a/src/services/company-officers/service.ts
+++ b/src/services/company-officers/service.ts
@@ -20,10 +20,10 @@ export default class CompanyOfficersService {
    * Those will also have full date of birth.Defaults to false
    * @param orderBy the field by which to order the result set
    */
-    public async getCompanyOfficers (number: string, pageSize: number = 35, pageIndex: number = 0, registerView: boolean = false, orderBy?: string): Promise<Resource<CompanyOfficers>> {
+    public async getCompanyOfficers (number: string, itemsPerPage: number = 35, pageIndex: number = 0, registerView: boolean = false, orderBy?: string): Promise<Resource<CompanyOfficers>> {
         let url = `/company/${number}/officers`;
         url = url.concat("?",
-            `page_size=${pageSize}`,
+            `items_per_page=${itemsPerPage}`,
             "&",
             `page_index=${pageIndex}`,
             "&",

--- a/test/services/company-officers/service.spec.ts
+++ b/test/services/company-officers/service.spec.ts
@@ -167,21 +167,21 @@ describe("company-officers", () => {
         const spy = sinon.spy(requestClient, "httpGet");
         const companyOfficers : CompanyOfficersService = new CompanyOfficersService(requestClient);
         await companyOfficers.getCompanyOfficers("123");
-        expect(spy.calledWith("/company/123/officers?page_size=35&page_index=0&register_view=false")).to.equal(true);
+        expect(spy.calledWith("/company/123/officers?items_per_page=35&page_index=0&register_view=false")).to.equal(true);
     });
 
     it("should pass url with specified parameters", async () => {
         const spy = sinon.spy(requestClient, "httpGet");
         const companyOfficers : CompanyOfficersService = new CompanyOfficersService(requestClient);
         await companyOfficers.getCompanyOfficers("123", 10, 2, true);
-        expect(spy.calledWith("/company/123/officers?page_size=10&page_index=2&register_view=true")).to.equal(true);
+        expect(spy.calledWith("/company/123/officers?items_per_page=10&page_index=2&register_view=true")).to.equal(true);
     });
 
     it("should pass url with orderBy parameter", async () => {
         const spy = sinon.spy(requestClient, "httpGet");
         const companyOfficers : CompanyOfficersService = new CompanyOfficersService(requestClient);
         await companyOfficers.getCompanyOfficers("123", 10, 2, true, "resigned_on");
-        expect(spy.calledWith("/company/123/officers?page_size=10&page_index=2&register_view=true&order_by=resigned_on")).to.equal(true);
+        expect(spy.calledWith("/company/123/officers?items_per_page=10&page_index=2&register_view=true&order_by=resigned_on")).to.equal(true);
     });
 
     it("maps the company field data correctly for specific appointment", async () => {


### PR DESCRIPTION
The service being called is the company-appointments.api.ch.gov.uk. The method expects a query param of 'items_per_page' not 'page_size' as was previously set.

https://github.com/companieshouse/company-appointments.api.ch.gov.uk/blob/535b637d88f4ab4e5754af9856603ac8610168f9/src/main/java/uk/gov/companieshouse/company_appointments/controller/CompanyAppointmentController.java#L56