### PR TITLE
lp-1852 - add get persons with significant control 

### DIFF
--- a/src/services/limited-partnerships/service.ts
+++ b/src/services/limited-partnerships/service.ts
@@ -256,6 +256,18 @@ export default class LimitedPartnershipsService {
         };
     }
 
+    public async getPersonsWithSignificantControl (
+        transactionId: string
+    ): Promise<Resource<PersonWithSignificantControl[]> | ApiErrorResponse> {
+        const URL = `/transactions/${transactionId}/limited-partnership/persons-with-significant-control`;
+        const response: HttpResponse = await this.client.httpGet(URL);
+
+        return {
+            httpStatusCode: response.status,
+            resource: response.body
+        };
+    }
+
     public async patchPersonWithSignificantControl (
         transactionId: string,
         personWithSignificantControlId: string,

--- a/src/services/limited-partnerships/types.ts
+++ b/src/services/limited-partnerships/types.ts
@@ -117,6 +117,7 @@ export interface PersonWithSignificantControl {
         registered_company_number?: string;
         principal_office_address?: Address;
         type?: PersonWithSignificantControlType;
+        completed?: boolean;
     }
 }
 

--- a/test/services/limited-partnerships/limited.partnerships.mock.ts
+++ b/test/services/limited-partnerships/limited.partnerships.mock.ts
@@ -206,7 +206,8 @@ export const PERSON_WITH_SIGNIFICANT_CONTROL_OBJECT_MOCK: PersonWithSignificantC
             country: "That Country",
             postal_code: "SC15 1N2"
         },
-        type: PersonWithSignificantControlType.INDIVIDUAL_PERSON
+        type: PersonWithSignificantControlType.INDIVIDUAL_PERSON,
+        completed: true
     }
 };
 
@@ -352,6 +353,12 @@ export const mockPostPersonWithSignificantControlResponse = {
 
 export const mockGetPersonWithSignificantControlResponse = {
     200: { status: 200, body: PERSON_WITH_SIGNIFICANT_CONTROL_OBJECT_MOCK },
+    404: { status: 404, body: { error: NOT_FOUND } },
+    401: { status: 401, body: { error: UNAUTHORISED } }
+};
+
+export const mockGetPersonsWithSignificantControlResponse = {
+    200: { status: 200, body: [PERSON_WITH_SIGNIFICANT_CONTROL_OBJECT_MOCK] },
     404: { status: 404, body: { error: NOT_FOUND } },
     401: { status: 401, body: { error: UNAUTHORISED } }
 };

--- a/test/services/limited-partnerships/limited.partnerships.spec.ts
+++ b/test/services/limited-partnerships/limited.partnerships.spec.ts
@@ -1081,7 +1081,7 @@ describe("LimitedPartnershipsService", () => {
             it("should return error 404 (Not Found)", async () => {
                 const mockRequest = sinon
                     .stub(mockValues.requestClient, "httpGet")
-                    .resolves(mockValues.mockGetPersonWithSignificantControlResponse[404]);
+                    .resolves(mockValues.mockGetPersonsWithSignificantControlResponse[404]);
 
                 const service = new LimitedPartnershipsService(
                     mockValues.requestClient

--- a/test/services/limited-partnerships/limited.partnerships.spec.ts
+++ b/test/services/limited-partnerships/limited.partnerships.spec.ts
@@ -1031,6 +1031,77 @@ describe("LimitedPartnershipsService", () => {
             });
         })
 
+        describe("getPersonsWithSignificantControl", () => {
+            it("should return a status 200 and the person with significant control object", async () => {
+                const mockRequest = sinon
+                    .stub(mockValues.requestClient, "httpGet")
+                    .resolves(mockValues.mockGetPersonsWithSignificantControlResponse[200]);
+
+                const service = new LimitedPartnershipsService(
+                    mockValues.requestClient
+                );
+
+                const response = await service.getPersonsWithSignificantControl(
+                    mockValues.TRANSACTION_ID
+                ) as Resource<PersonWithSignificantControl[]>;
+
+                expect(mockRequest).to.have.been.calledOnce;
+                expect(
+                    mockRequest.calledWith(
+                        "/transactions/12345/limited-partnership/persons-with-significant-control"
+                    )
+                ).to.be.true;
+                expect(response.httpStatusCode).to.equal(200);
+                expect(response?.resource).to.eql([mockValues.PERSON_WITH_SIGNIFICANT_CONTROL_OBJECT_MOCK]);
+            });
+
+            it("should return error 401 (Unauthorised)", async () => {
+                const mockRequest = sinon
+                    .stub(mockValues.requestClient, "httpGet")
+                    .resolves(mockValues.mockGetPersonsWithSignificantControlResponse[401]);
+
+                const service = new LimitedPartnershipsService(
+                    mockValues.requestClient
+                );
+                const response = (await service.getPersonsWithSignificantControl(
+                    mockValues.TRANSACTION_ID
+                )) as Resource<any>;
+
+                expect(mockRequest).to.have.been.calledOnce;
+                expect(
+                    mockRequest.calledWith(
+                        "/transactions/12345/limited-partnership/persons-with-significant-control"
+                    )
+                ).to.be.true;
+
+                expect(response.httpStatusCode).to.equal(401);
+                expect(response.resource.error).to.equal(mockValues.UNAUTHORISED);
+            });
+
+            it("should return error 404 (Not Found)", async () => {
+                const mockRequest = sinon
+                    .stub(mockValues.requestClient, "httpGet")
+                    .resolves(mockValues.mockGetPersonWithSignificantControlResponse[404]);
+
+                const service = new LimitedPartnershipsService(
+                    mockValues.requestClient
+                );
+                const response = (await service.getPersonsWithSignificantControl(
+                    "wrong-id"
+                )) as Resource<any>;
+
+                expect(mockRequest).to.have.been.calledOnce;
+                expect(
+                    mockRequest.calledWith(
+                        "/transactions/wrong-id/limited-partnership/persons-with-significant-control"
+                    )
+                ).to.be.true;
+
+                expect(response.httpStatusCode).to.equal(404);
+                expect(response.resource.error).to.equal(mockValues.NOT_FOUND);
+            });
+        })
+
         describe("patchPersonWithSignificantControl", () => {
             it("should return 200 patchPersonWithSignificantControl method", async () => {
                 const mockRequest = sinon


### PR DESCRIPTION
*** JIRA link ***
https://companieshouse.atlassian.net/browse/LP-1852

*** Change description ***
Add get persons with significant control endpoint to sdk
update PSC type to include 'completed' boolean.
add tests

### Work checklist

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist
* [x] I have added unit tests for new code that I have added

*** Merge instructions ***
We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
[optional scope]:
```

and contain the following structural elements:

fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
footers other than `BREAKING CHANGE: ` may be provided.