### PR TITLE
LP-1921 Add new LP PSC fields for title, names, consent

### DIFF
--- a/src/services/limited-partnerships/types.ts
+++ b/src/services/limited-partnerships/types.ts
@@ -102,8 +102,10 @@ export interface PersonWithSignificantControl {
         resignation_date?: string;
         natures_of_control?: NaturesOfControl[];
         service_address?: Address;
+        title?: string;
         forename?: string;
         former_names?: string;
+        middle_names?: string;
         surname?: string;
         date_of_birth?: string;
         nationality1?: string;
@@ -118,6 +120,7 @@ export interface PersonWithSignificantControl {
         principal_office_address?: Address;
         type?: PersonWithSignificantControlType;
         completed?: boolean;
+        consent_checked?: boolean;
     }
 }
 

--- a/test/services/limited-partnerships/limited.partnerships.mock.ts
+++ b/test/services/limited-partnerships/limited.partnerships.mock.ts
@@ -159,11 +159,14 @@ export const LIMITED_PARTNER_OBJECT_MOCK: LimitedPartner = {
 export const PERSON_WITH_SIGNIFICANT_CONTROL_OBJECT_MOCK: PersonWithSignificantControl = {
     id: "123456",
     data: {
+        consent_checked: true,
         date_effective_from: "2005-02-04",
         appointment_id: "112233",
         date_of_birth: "2000-05-01",
+        title: "Mr",
         forename: "John",
         former_names: "Mary",
+        middle_names: "James",
         governing_law: "British Government",
         kind: "",
         legal_entity_name: "My company ltd",


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/LP-1921

This pull request updates the `PersonWithSignificantControl` type and its related mock data to include additional personal details and a consent flag. These changes enhance the data structure to better capture individual information and compliance status.

Enhancements to `PersonWithSignificantControl` type:

* Added new optional fields: `title`, `middle_names`, and `consent_checked` to the `PersonWithSignificantControl` interface in `types.ts`. These fields allow for more detailed personal information and tracking of consent status. [[1]](diffhunk://#diff-0b38378ef7839c5972b9299d37e4c6310b56e246d749e7ec857453f02955cba8R105-R108) [[2]](diffhunk://#diff-0b38378ef7839c5972b9299d37e4c6310b56e246d749e7ec857453f02955cba8R123)

Updates to mock data for testing:

* Updated the `PERSON_WITH_SIGNIFICANT_CONTROL_OBJECT_MOCK` in `limited.partnerships.mock.ts` to include values for the new fields: `consent_checked`, `title`, and `middle_names`. This ensures that tests reflect the expanded data structure.