### PR TITLE
ASM-2299 Run npm audit fix to resolve new 'qs' vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5738,9 +5738,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.15.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+            "version": "6.15.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {


### PR DESCRIPTION
up to date, audited 567 packages in 8s

164 packages are looking for funding
  run `npm fund` for details

# npm audit report

uuid  <11.1.1
Severity: moderate
uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided - https://github.com/advisories/GHSA-w5hq-g745-h8pq fix available via `npm audit fix --force`
Will install nyc@14.1.1, which is a breaking change node_modules/uuid
  istanbul-lib-processinfo  *
  Depends on vulnerable versions of uuid
  node_modules/istanbul-lib-processinfo
    nyc  >=15.0.0-alpha.0
    Depends on vulnerable versions of istanbul-lib-processinfo
    node_modules/nyc
      @istanbuljs/nyc-config-typescript  >=1.0.1
      Depends on vulnerable versions of nyc
      node_modules/@istanbuljs/nyc-config-typescript

4 moderate severity vulnerabilities

To address all issues (including breaking changes), run:
  npm audit fix --force to resolve new 'qs' vulnerability