### PR TITLE
Task/fix vulnerabilities on version 2.0.352

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ To tun the tests with coverage, pass the `--coverage` flag on the command line.
   - Reason: Required as a transitive dependency by mocha@11.7.2, which depends on vulnerable version 6.0.2.
   - Ticket/CVE: CVE-2026-34043
   - Remove after: Remove once Mocha has been upgraded beyond version 11.7.2 (patch or minor release). Ensure proper testing is completed after removal.
+
 - "uuid": "^11.1.1"
   - Reason: transitive dependency of istanbul-lib-processinfo / nyc
   - Ticket: ASM-2299 ( gulnerability GHSA-w5hq-g745-h8pq )
+
+- **js-yaml@4.2.0**
+  - Reason: Required as a transitive dependency by @istanbuljs/load-nyc-config@1.1.0, which depends on vulnerable version 3.13.1.
+  - Ticket/CVE: CVE-2026-53550 ( vulnerability GHSA-h67p-54hq-rp68 )
+  - Remove after: Remove once load-nyc-config has been upgraded beyond version 1.1.0 (patch or minor release). Ensure proper testing is completed after removal.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -484,16 +484,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -506,20 +496,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -1145,9 +1121,9 @@
             "license": "ISC"
         },
         "node_modules/acorn": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-            "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -1468,9 +1444,9 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-            "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
@@ -1480,16 +1456,16 @@
             }
         },
         "node_modules/axios/node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -1503,9 +1479,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.32",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
-            "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+            "version": "2.10.38",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+            "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -1682,9 +1658,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001793",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-            "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+            "version": "1.0.30001799",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+            "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
             "dev": true,
             "funding": [
                 {
@@ -2192,9 +2168,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.361",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
-            "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
+            "version": "1.5.375",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
+            "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
             "dev": true,
             "license": "ISC"
         },
@@ -2274,6 +2250,25 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/es-abstract-get": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+            "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.2",
+                "is-callable": "^1.2.7",
+                "object-inspect": "^1.13.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/es-define-property": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -2333,15 +2328,17 @@
             }
         },
         "node_modules/es-to-primitive": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-            "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.1.tgz",
+            "integrity": "sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "es-abstract-get": "^1.0.0",
+                "es-errors": "^1.3.0",
                 "is-callable": "^1.2.7",
-                "is-date-object": "^1.0.5",
-                "is-symbol": "^1.0.4"
+                "is-date-object": "^1.1.0",
+                "is-symbol": "^1.1.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2474,9 +2471,9 @@
             }
         },
         "node_modules/eslint-module-utils": {
-            "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
-            "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
+            "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2758,20 +2755,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/esquery": {
@@ -3068,16 +3051,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "2.5.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-            "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+            "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
+                "hasown": "^2.0.4",
                 "mime-types": "^2.1.35",
                 "safe-buffer": "^5.2.1"
             },
@@ -3134,18 +3117,21 @@
             }
         },
         "node_modules/function.prototype.name": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-            "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+            "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.3",
-                "define-properties": "^1.2.1",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
                 "functions-have-names": "^1.2.3",
-                "hasown": "^2.0.2",
-                "is-callable": "^1.2.7"
+                "has-property-descriptors": "^1.0.2",
+                "hasown": "^2.0.4",
+                "is-callable": "^1.2.7",
+                "is-document.all": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3517,9 +3503,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -3782,6 +3768,22 @@
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-document.all": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+            "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -4188,9 +4190,9 @@
             }
         },
         "node_modules/istanbul-lib-processinfo": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-3.0.0.tgz",
-            "integrity": "sha512-P7nLXRRlo7Sqinty6lNa7+4o9jBUYGpqtejqCOZKfgXlRoxY/QArflcB86YO500Ahj4pDJEG34JjMRbQgePLnQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-3.0.1.tgz",
+            "integrity": "sha512-s3mX05h5wGZeScG6XnOanygPh4SJu5ujMc9YbvpnLGXWy1cRiGbp0NdVcjHxgoZt3WfQppfBsa0y+gWdYJ2pGQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4198,8 +4200,7 @@
                 "cross-spawn": "^7.0.3",
                 "istanbul-lib-coverage": "^3.2.0",
                 "p-map": "^3.0.0",
-                "rimraf": "^6.1.3",
-                "uuid": "^8.3.2"
+                "rimraf": "^6.1.3"
             },
             "engines": {
                 "node": "20 || >=22"
@@ -4247,9 +4248,9 @@
             }
         },
         "node_modules/istanbul-lib-processinfo/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -4406,10 +4407,20 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -4903,9 +4914,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.46",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
-            "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+            "version": "2.0.48",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+            "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5042,9 +5053,9 @@
             }
         },
         "node_modules/nyc/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -6138,9 +6149,9 @@
             "license": "ISC"
         },
         "node_modules/serialize-javascript": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
-            "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
+            "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -6227,15 +6238,15 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },
@@ -6511,9 +6522,9 @@
             }
         },
         "node_modules/spawn-wrap/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -6579,13 +6590,6 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "dev": true,
-            "license": "BSD-3-Clause"
         },
         "node_modules/stop-iteration-iterator": {
             "version": "1.1.0",
@@ -6689,19 +6693,20 @@
             }
         },
         "node_modules/string.prototype.trim": {
-            "version": "1.2.10",
-            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-            "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+            "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.2",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
                 "define-data-property": "^1.1.4",
                 "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.5",
-                "es-object-atoms": "^1.0.0",
-                "has-property-descriptors": "^1.0.2"
+                "es-abstract": "^1.24.2",
+                "es-object-atoms": "^1.1.2",
+                "has-property-descriptors": "^1.0.2",
+                "safe-regex-test": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6711,16 +6716,16 @@
             }
         },
         "node_modules/string.prototype.trimend": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-            "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+            "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.2",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
                 "define-properties": "^1.2.1",
-                "es-object-atoms": "^1.0.0"
+                "es-object-atoms": "^1.1.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6913,9 +6918,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -7196,18 +7201,18 @@
             }
         },
         "node_modules/typed-array-length": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-            "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+            "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "is-typed-array": "^1.1.13",
-                "possible-typed-array-names": "^1.0.0",
-                "reflect.getprototypeof": "^1.0.6"
+                "call-bind": "^1.0.9",
+                "for-each": "^0.3.5",
+                "gopd": "^1.2.0",
+                "is-typed-array": "^1.1.15",
+                "possible-typed-array-names": "^1.1.0",
+                "reflect.getprototypeof": "^1.0.10"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7313,20 +7318,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/uuid": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-            "dev": true,
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/esm/bin/uuid"
-            }
-        },
         "node_modules/v8-compile-cache-lib": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -7425,14 +7416,14 @@
             "license": "ISC"
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.20",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-            "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+            "version": "1.1.22",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+            "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.8",
+                "call-bind": "^1.0.9",
                 "call-bound": "^1.0.4",
                 "for-each": "^0.3.5",
                 "get-proto": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
         "semver": "7.5.2",
         "diff": "^8.0.2",
         "uuid": "^11.1.1",
-        "serialize-javascript": "^7.0.5"
+        "serialize-javascript": "^7.0.5",
+        "@istanbuljs/load-nyc-config@1.1.0": {
+            "js-yaml": "^4.2.0"
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the `JS-Yaml` Quadratic-complexity DoS in merge key handling via repeated aliases vulnerability as the vulnerable version `3.13.1` is required as a transitive dependency by `@istanbuljs/load-nyc-config@1.1.0`.