### PR TITLE
CSE-1367: ACSP: Pull Condensed SIC Code List directly from MongoDB using CS API

### DIFF
--- a/src/services/confirmation-statement/service.ts
+++ b/src/services/confirmation-statement/service.ts
@@ -46,6 +46,7 @@ import {
 } from "./types";
 import { HttpResponse, IHttpClient } from "../../http";
 import Resource, { ApiErrorResponse } from "../resource";
+import { CondensedSicCodeData } from "../sic-code/types";
 export default class {
     constructor (private readonly client: IHttpClient) { }
 
@@ -270,6 +271,29 @@ export default class {
         resource.resource = this.mapToNextMadeUpToDate(resp.body);
 
         return resource;
+    }
+
+    public async getCondensedSicCodeList (): Promise<Resource<CondensedSicCodeData[]>> {
+        const url: string = "/confirmation-statement/condensed-sic-codes";
+        const response: HttpResponse = await this.client.httpGet(url);
+
+        const condensedSicCodeResource: Resource<CondensedSicCodeData[]> = {
+            httpStatusCode: response.status
+        };
+
+        if (response.error && response.status !== 400) {
+            condensedSicCodeResource.resource = response.error;
+            return condensedSicCodeResource;
+        }
+
+        const subResource: CondensedSicCodeData[] = response.body ? response.body : response.error;
+
+        if (!subResource) {
+            throw new Error(`No body or error body returned from ${url} API call - http status from API = ${response.status}`);
+        }
+        condensedSicCodeResource.resource = subResource;
+
+        return condensedSicCodeResource;
     }
 
     private mapToConfirmationStatementSubmission (apiResource: ConfirmationStatementSubmissionResource): ConfirmationStatementSubmission {

--- a/test/services/confirmation-statement/confirmation.statement.spec.ts
+++ b/test/services/confirmation-statement/confirmation.statement.spec.ts
@@ -16,6 +16,7 @@ import { expect } from "chai";
 import sinon from "sinon";
 import { mockGetPersonsOfSignificantControl, mockGetShareholder, mockGetRegisterLocations } from "./confirmation.statement.mock";
 import Resource, { ApiErrorResponse } from "../../../src/services/resource";
+import { CondensedSicCodeData } from "../../../src/services/sic-code";
 
 const TRANSACTION_ID = "12345";
 const CONFIRMATION_STATEMENT_ID = "r4nd0m";
@@ -480,5 +481,70 @@ describe("getNextMadeUpToDate tests", () => {
 
         expect(response.httpStatusCode).to.equal(404);
         expect(response.errors[0]).to.equal("Not Found");
+    });
+});
+
+describe.only("Get condensed sic code list from confirmation service", () => {
+    it("Should return condensed sic code list", async () => {
+        const mockResponseBody = [
+            { sic_code: "15110", sic_description: "Tanning and dressing of leather; dressing and dyeing of fur" },
+            { sic_code: "16220", sic_description: "Manufacture of assembled parquet floors" },
+            { sic_code: "16100", sic_description: "Sawmilling and planing of wood" }
+        ];
+
+        sinon.stub(mockValues.requestClient, "httpGet").resolves({
+            status: 200,
+            body: mockResponseBody
+        });
+
+        const csService: ConfirmationStatementService = new ConfirmationStatementService(mockValues.requestClient);
+
+        const response = await csService.getCondensedSicCodeList() as Resource<CondensedSicCodeData[]>;
+
+        expect(response.httpStatusCode).to.be.equal(200);
+        expect(response.resource).to.be.equal(mockResponseBody);
+    });
+
+    it("Should return an error when sic code api response status = 400", async () => {
+        sinon.stub(mockValues.requestClient, "httpGet").resolves({
+            status: 400,
+            error: "Bad Request"
+        });
+
+        const csService: ConfirmationStatementService = new ConfirmationStatementService(mockValues.requestClient);
+
+        const response = await csService.getCondensedSicCodeList() as Resource<CondensedSicCodeData[]>;
+
+        expect(response.httpStatusCode).to.be.equal(400);
+        expect(response.resource).to.be.equal("Bad Request");
+    });
+
+    it("Should return an error when sic code api response status = 500", async () => {
+        sinon.stub(mockValues.requestClient, "httpGet").resolves({
+            status: 500,
+            error: "Internal Server Error"
+        });
+
+        const csService: ConfirmationStatementService = new ConfirmationStatementService(mockValues.requestClient);
+
+        const response = await csService.getCondensedSicCodeList() as Resource<CondensedSicCodeData[]>;
+
+        expect(response.httpStatusCode).to.be.equal(500);
+        expect(response.resource).to.be.equal("Internal Server Error");
+    });
+
+    it("Should throw an error when response body and error are null", async () => {
+        sinon.stub(mockValues.requestClient, "httpGet").resolves({
+            status: 404,
+            error: undefined
+        });
+
+        const csService: ConfirmationStatementService = new ConfirmationStatementService(mockValues.requestClient);
+
+        try {
+            csService.getCondensedSicCodeList();
+        } catch (error) {
+            expect((error as Error).message).to.equal("No body or error body returned from /confirmation-statement/condensed-sic-codes API call - http status from API = 404");
+        }
     });
 });

--- a/test/services/confirmation-statement/confirmation.statement.spec.ts
+++ b/test/services/confirmation-statement/confirmation.statement.spec.ts
@@ -484,7 +484,7 @@ describe("getNextMadeUpToDate tests", () => {
     });
 });
 
-describe.only("Get condensed sic code list from confirmation service", () => {
+describe("Get condensed sic code list from confirmation service", () => {
     it("Should return condensed sic code list", async () => {
         const mockResponseBody = [
             { sic_code: "15110", sic_description: "Tanning and dressing of leather; dressing and dyeing of fur" },


### PR DESCRIPTION
Ticket:
https://companieshouse.atlassian.net/browse/CSE-1367

Changes:
- Added API Call to Retrieve the condensed Sic Code List from Confirmation Statement API
- Added the unit test for getCondensedSicCodeList method